### PR TITLE
ppx, cohttp and angstrom

### DIFF
--- a/packages/angstrom-windows.0.1.1/descr
+++ b/packages/angstrom-windows.0.1.1/descr
@@ -1,0 +1,9 @@
+Parser combinators built for speed and memory-efficiency
+
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking
+by default and support unbounded lookahead.

--- a/packages/angstrom-windows.0.1.1/findlib
+++ b/packages/angstrom-windows.0.1.1/findlib
@@ -1,0 +1,1 @@
+angstrom

--- a/packages/angstrom-windows.0.1.1/opam
+++ b/packages/angstrom-windows.0.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/angstrom"
+bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
+dev-repo: "https://github.com/inhabitedtype/angstrom.git"
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+    "ocaml" "setup.ml" "-configure" "--prefix" prefix
+    "--enable-unix"
+    "--%{lwt-windows:enable}%-lwt"
+    "--disable-async"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" "ocaml" "setup.ml" "-build"]
+]
+install: ["env" "OCAMLFIND_TOOLCHAIN=windows" "ocaml" "setup.ml" "-install"]
+remove: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" "ocamlfind" "remove" "angstrom"]
+]
+depends: [
+  "cstruct-windows" {>= "0.6.0"}
+  "result-windows"
+  "ocplib-endian-windows" {>= "0.6"}
+  "ocaml-windows"
+]
+depopts: [
+  "lwt-windows"
+]
+available: [ ocaml-version >= "4.00.0" ]

--- a/packages/angstrom-windows.0.1.1/url
+++ b/packages/angstrom-windows.0.1.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/inhabitedtype/angstrom/archive/0.1.1.tar.gz"
+checksum: "ecc3dd0accdc39b74c48997eaba5f3e9"

--- a/packages/cohttp-windows.0.21.0/descr
+++ b/packages/cohttp-windows.0.21.0/descr
@@ -1,0 +1,9 @@
+HTTP(S) library for Lwt, Async and Mirage
+
+There are several optional dependencies which activate functionality:
+
+* Lwt: `opam install lwt cohttp`
+* Lwt and SSL: `opam install lwt ssl cohttp`
+* Async: `opam install async cohttp`
+* Async and SSL: `opam install async_ssl cohttp`
+

--- a/packages/cohttp-windows.0.21.0/opam
+++ b/packages/cohttp-windows.0.21.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  [ "env" "OCAMLFIND_TOOLCHAIN=windows" make "PREFIX=%{prefix}%/windows-sysroot" "build" ]
+]
+install: ["env" "OCAMLFIND_TOOLCHAIN=windows" make "PREFIX=%{prefix}%/windows-sysroot" "install"]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "cohttp"]
+depends: [
+  "ocaml-windows"
+  "re-windows"
+  "uri-windows" {>= "1.9.0"}
+  "fieldslib-windows"
+  "sexplib-windows"
+  "conduit-windows" {>= "0.11.0"}
+  "ppx_fields_conv-windows"
+  "ppx_sexp_conv-windows"
+  "stringext-windows"
+  "base64-windows" {>= "2.0.0"}
+  "magic-mime-windows"
+]
+depopts: ["lwt-windows"]
+conflicts: [
+  "lwt-windows" {< "2.5.0"}
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/cohttp-windows.0.21.0/url
+++ b/packages/cohttp-windows.0.21.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cohttp/archive/v0.21.0.tar.gz"
+checksum: "ce54a6363da401eb774fcad8a47e31a5"

--- a/packages/conduit-windows.0.13.0/descr
+++ b/packages/conduit-windows.0.13.0/descr
@@ -1,0 +1,15 @@
+Network connection library for TCP and SSL
+
+The `conduit` library takes care of establishing and listening for TCP and
+SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways to bind to
+a library (e.g. the C FFI, or the Ctypes library), as well as well as which
+library is used (either OpenSSL or a native OCaml TLS implementation).
+
+If you are using the `Lwt_unix` version of the library, you can set two
+environment variables to control the behaviour of the library:
+
+- `CONDUIT_DEBUG=1` will output debug information to standard error.
+- `CONDUIT_TLS=native` will force the use of the pure OCaml TLS library.

--- a/packages/conduit-windows.0.13.0/opam
+++ b/packages/conduit-windows.0.13.0/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"]
+homepage:     "https://github.com/mirage/ocaml-conduit"
+dev-repo:     "https://github.com/mirage/ocaml-conduit.git"
+bug-reports:  "https://github.com/mirage/ocaml-conduit/issues"
+tags:         "org:mirage"
+license:      "ISC"
+
+build:   [
+  [make "ppx"]
+  ["ocamlbuild" "-use-ocamlfind" "-just-plugin"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" make]
+]
+install: ["env" "OCAMLFIND_TOOLCHAIN=windows" make "install"]
+remove:  ["ocamlfind" "-toolchain" "windows" "remove" "conduit"]
+
+depends: [
+  "ocaml-windows"
+  "ocamlbuild" {build}
+  "ppx_driver-windows" {build}
+  "ppx_optcomp-windows" {build & >="113.24.00"}
+  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv-windows" {build}
+  "sexplib-windows"
+  "stringext-windows"
+  "uri-windows"
+# Removing ssl for now because it breaks mxe+ocaml
+#  "ssl-windows"
+  "cstruct-windows" {>="1.0.1"}
+  "ipaddr-windows" {>="2.5.0"}
+  "lwt-windows"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/conduit-windows.0.13.0/url
+++ b/packages/conduit-windows.0.13.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-conduit/archive/v0.13.0.tar.gz"
+checksum: "c04f0906789cf305994ca932960515c9"

--- a/packages/cstruct-windows.2.3.0/descr
+++ b/packages/cstruct-windows.2.3.0/descr
@@ -1,0 +1,22 @@
+access C structures via a camlp4 extension
+
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the Bigarray module.
+
+An example pcap description using PPX extension points is:
+
+```
+[%%cstruct
+type pcap_header = {
+  magic_number: uint32_t;   (* magic number *)
+  version_major: uint16_t;  (* major version number *)
+  version_minor: uint16_t;  (* minor version number *)
+  thiszone: uint32_t;       (* GMT to local correction *)
+  sigfigs: uint32_t;        (* accuracy of timestamps *)
+  snaplen: uint32_t;        (* max length of captured packets, in octets *)
+  network: uint32_t;        (* data link type *)
+} [@@little_endian]]
+```
+
+For Camlp4 support, please use a version of Cstruct that is `<=1.9.0`

--- a/packages/cstruct-windows.2.3.0/opam
+++ b/packages/cstruct-windows.2.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-configure"
+     "--prefix" "%{prefix}%/windows-sysroot"
+     "--override" "ext_dll" ".dll"
+     "--%{lwt-windows:enable}%-lwt"
+     "--disable-ppx"
+     "--disable-async"
+     "--enable-unix"]
+  ["ocamlbuild" "-use-ocamlfind" "-just-plugin"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-install"]
+]
+remove:  [
+  ["ocamlfind" "-toolchain" "windows" "remove" "cstruct"]
+]
+depends: [
+  "ocplib-endian-windows"
+  "sexplib-windows"
+  "ocaml-windows"
+]
+depopts: [
+  "lwt-windows"
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/cstruct-windows.2.3.0/url
+++ b/packages/cstruct-windows.2.3.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-cstruct/archive/v2.3.0.tar.gz"
+checksum: "f84097a0618715e2849542ee8e893454"

--- a/packages/fieldslib-windows.113.24.00/descr
+++ b/packages/fieldslib-windows.113.24.00/descr
@@ -1,0 +1,5 @@
+Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/fieldslib-windows.113.24.00/opam
+++ b/packages/fieldslib-windows.113.24.00/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/fieldslib"
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "https://github.com/janestreet/fieldslib.git"
+license: "Apache-2.0"
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" "./configure" "--prefix" prefix]
+  ["ocamlbuild" "-just-plugin"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "fieldslib.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "fieldslib"]
+depends: [
+  "ocamlbuild" {build}
+  "ocaml-windows"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/fieldslib-windows.113.24.00/url
+++ b/packages/fieldslib-windows.113.24.00/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.24/files/fieldslib-113.24.00.tar.gz"
+checksum: "3afa341134a5e4e4b583f6c617fa4e72"

--- a/packages/ipaddr-windows.2.7.0/descr
+++ b/packages/ipaddr-windows.2.7.0/descr
@@ -1,0 +1,23 @@
+IP (and MAC) address representation library
+
+A library for manipulation of IP (and MAC) address representations.
+
+Features:
+
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 CIDR-scoped address support
+ * Ipaddr.V4 and Ipaddr.V4.Prefix modules are Map.OrderedType
+ * Ipaddr.V6 and Ipaddr.V6.Prefix modules are Map.OrderedType
+ * Ipaddr and Ipaddr.Prefix modules are Map.OrderedType
+ * Ipaddr_unix in findlib subpackage ipaddr.unix provides compatibility
+   with the standard library Unix module
+ * Ipaddr_top in findlib subpackage ipaddr.top provides top-level pretty
+   printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * Macaddr is a Map.OrderedType
+ * All types have sexplib serializers/deserializers

--- a/packages/ipaddr-windows.2.7.0/opam
+++ b/packages/ipaddr-windows.2.7.0/opam
@@ -1,0 +1,39 @@
+opam-version: "1.2"
+maintainer:   "sheets@alum.mit.edu"
+authors: [
+              "David Sheets"
+              "Anil Madhavapeddy"
+              "Hugo Heuzard"
+]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-ipaddr"
+bug-reports:  "https://github.com/mirage/ocaml-ipaddr/issues"
+dev-repo:     "https://github.com/mirage/ocaml-ipaddr.git"
+
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%/windows-sysroot"
+                                   "--override" "ext_dll" ".dll"]
+  ["ocamlbuild" "-use-ocamlfind" "-just-plugin"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "-toolchain" "windows" "remove" "ipaddr"]
+]
+depends: [
+  "ocaml-windows"
+  "ocamlbuild" {build}
+  "sexplib-windows"
+  "ppx_sexp_conv-windows"
+]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/ipaddr-windows.2.7.0/url
+++ b/packages/ipaddr-windows.2.7.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-ipaddr/archive/2.7.0.tar.gz"
+checksum: "48389ef61662181069de9456c5d3aeb1"

--- a/packages/ppx_blob-windows.0.2/descr
+++ b/packages/ppx_blob-windows.0.2/descr
@@ -1,0 +1,1 @@
+Include a file as a string at compile time

--- a/packages/ppx_blob-windows.0.2/opam
+++ b/packages/ppx_blob-windows.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "ppx_blob"
+version: "0.2"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+build: [
+  [make "native-code"]
+]
+install: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" make "install"]
+]
+remove: [["ocamlfind" "-toolchain" "windows" "remove" "ppx_blob"]]
+depends: [
+  "ppx_tools" {build}
+  "ocaml-windows"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/ppx_blob-windows.0.2/url
+++ b/packages/ppx_blob-windows.0.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/johnwhitington/ppx_blob/archive/v0.2.tar.gz"
+checksum: "c25401923d7e6efe6af400f1100c7923"

--- a/packages/ppx_core-windows.113.33.01+4.03/descr
+++ b/packages/ppx_core-windows.113.33.01+4.03/descr
@@ -1,0 +1,2 @@
+Standard library for ppx rewriters
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_core-windows.113.33.01+4.03/files/META.ab
+++ b/packages/ppx_core-windows.113.33.01+4.03/files/META.ab
@@ -1,0 +1,17 @@
+version = "$(pkg_version)"
+description = "Standard library for ppx rewriters"
+#requires = "compiler-libs.common"
+archive(byte  ) = "ppx_core.cma"
+archive(native) = "ppx_core.cmxa"
+plugin(byte  ) = "ppx_core.cma"
+plugin(native) = "ppx_core.cmxs"
+exists_if = "ppx_core.cma"
+
+# Until this is released: https://github.com/whitequark/ppx_deriving/pull/95
+package "for_ppx_deriving" (
+  description = "Don't use this directly"
+  error(ppx_driver) = "Cannot use ppx_core.for_ppx_deriving when ppx_driver is set"
+#  requires = "compiler-libs.common ppx_deriving"
+  exists_if = "ppx_core.cma"
+  ppxopt(-custom_ppx) = "ppx_deriving,./ppx_core.cma"
+)

--- a/packages/ppx_core-windows.113.33.01+4.03/opam
+++ b/packages/ppx_core-windows.113.33.01+4.03/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_core"
+bug-reports: "https://github.com/janestreet/ppx_core/issues"
+dev-repo: "https://github.com/janestreet/ppx_core.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" "%{prefix}%/windows-sysroot"]
+  [make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_core.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_core"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_core-windows.113.33.01+4.03/opam
+++ b/packages/ppx_core-windows.113.33.01+4.03/opam
@@ -12,8 +12,8 @@ build: [
 install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_core.install"]]
 remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_core"]
 depends: [
+  "ocaml-windows"
   "ocamlbuild" {build}
-  "ocamlfind"  {build & >= "1.3.2"}
   "ppx_tools"  {>= "0.99.3"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_core-windows.113.33.01+4.03/url
+++ b/packages/ppx_core-windows.113.33.01+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_core-113.33.01+4.03.tar.gz"
+checksum: "8270531d5b0b595f66e08bc9456e4042"

--- a/packages/ppx_defer-windows.0.2.0/descr
+++ b/packages/ppx_defer-windows.0.2.0/descr
@@ -1,0 +1,4 @@
+A syntax extension to provide a somewhat Go-like defer
+
+`[%defer e1]; e2` or `[%defer.lwt e1]; e2` will defer the evaluation of `e1`
+until after `e2` is evaluated.

--- a/packages/ppx_defer-windows.0.2.0/opam
+++ b/packages/ppx_defer-windows.0.2.0/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "ppx_defer"
+version: "0.2.0"
+maintainer: "Hezekiah M. Carty <hez@0ok.org>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "MIT"
+homepage: "https://github.com/hcarty/ppx_defer"
+bug-reports: "https://github.com/hcarty/ppx_defer/issues"
+dev-repo: "https://github.com/hcarty/ppx_defer.git"
+tags: [ "syntax" ]
+build:[
+  "ocaml" "pkg/build.ml" "native=true"
+                         "native-dynlink=true"
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_defer.install"]]
+remove: [["ocamlfind" "-toolchain" "windows" "remove" "ppx_defer"]]
+depends: [
+  "ppx_tools" {>= "0.99.3"}
+  "ocamlbuild" {build}
+  "ocaml-windows"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/ppx_defer-windows.0.2.0/url
+++ b/packages/ppx_defer-windows.0.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/hcarty/ppx_defer/archive/v0.2.0.tar.gz"
+checksum: "a9505957d567684a753f661c583c2b8a"

--- a/packages/ppx_deriving-windows.3.3/descr
+++ b/packages/ppx_deriving-windows.3.3/descr
@@ -1,0 +1,5 @@
+Type-driven code generation for OCaml >=4.02
+
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.

--- a/packages/ppx_deriving-windows.3.3/files/pkg/META.in
+++ b/packages/ppx_deriving-windows.3.3/files/pkg/META.in
@@ -1,0 +1,138 @@
+version = "%{version}%"
+description = "Type-driven code generation"
+ppx(-custom_ppx) = "./native/ppx_deriving"
+requires = "ppx_deriving.runtime"
+
+package "runtime" (
+  version = "%{version}%"
+  requires = "result"
+  description = "Runtime component of built-in derivers"
+  archive(byte) = "ppx_deriving_runtime.cma"
+  archive(native) = "ppx_deriving_runtime.cmxa"
+  exists_if = "ppx_deriving_runtime.cma"
+)
+
+package "api" (
+  version = "%{version}%"
+  description = "Plugin API for ppx_deriving"
+  requires = "dynlink compiler-libs.common ppx_tools result"
+  archive(byte) = "ppx_deriving.cma"
+  archive(native) = "ppx_deriving.cmxa"
+  exists_if = "ppx_deriving.cma"
+)
+
+package "main" (
+  version = "%{version}%"
+  description = "Runner for ppx_deriving"
+  requires = "ppx_deriving.api"
+  archive(byte) = "ppx_deriving_main.cma"
+  archive(native) = "ppx_deriving_main.cmxa"
+  exists_if = "ppx_deriving_main.cma"
+)
+
+package "std" (
+  version = "%{version}%"
+  description = "Meta-package for all built-in derivers"
+  requires  = "ppx_deriving.show ppx_deriving.eq ppx_deriving.ord"
+  requires += "ppx_deriving.enum ppx_deriving.iter ppx_deriving.map"
+  requires += "ppx_deriving.fold ppx_deriving.create ppx_deriving.make"
+)
+
+package "show" (
+  version = "%{version}%"
+  description = "[@@deriving show]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_show.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_show.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_show.cmxa"
+  exists_if = "native/ppx_deriving_show.cma"
+)
+
+package "eq" (
+  version = "%{version}%"
+  description = "[@@deriving eq]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_eq.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_eq.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_eq.cmxa"
+  exists_if = "native/ppx_deriving_eq.cma"
+)
+
+package "ord" (
+  version = "%{version}%"
+  description = "[@@deriving ord]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_ord.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_ord.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_ord.cmxa"
+  exists_if = "native/ppx_deriving_ord.cma"
+)
+
+package "enum" (
+  version = "%{version}%"
+  description = "[@@deriving enum]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_enum.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_enum.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_enum.cmxa"
+  exists_if = "native/ppx_deriving_enum.cma"
+)
+
+package "iter" (
+  version = "%{version}%"
+  description = "[@@deriving iter]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_iter.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_iter.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_iter.cmxa"
+  exists_if = "native/ppx_deriving_iter.cma"
+)
+
+package "map" (
+  version = "%{version}%"
+  description = "[@@deriving map]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_map.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_map.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_map.cmxa"
+  exists_if = "native/ppx_deriving_map.cma"
+)
+
+package "fold" (
+  version = "%{version}%"
+  description = "[@@deriving fold]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_fold.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_fold.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_fold.cmxa"
+  exists_if = "native/ppx_deriving_fold.cma"
+)
+
+package "create" (
+  version = "%{version}%"
+  description = "[@@deriving create]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_create.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_create.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_create.cmxa"
+  exists_if = "native/ppx_deriving_create.cma"
+)
+
+package "make" (
+  version = "%{version}%"
+  description = "[@@deriving make]"
+  requires(-ppx_driver) = "ppx_deriving"
+  ppxopt(-ppx_driver,-custom_ppx) = "ppx_deriving,./native/ppx_deriving_make.cma"
+  requires(ppx_driver) = "ppx_deriving.api"
+  archive(ppx_driver, byte) = "native/ppx_deriving_make.cma"
+  archive(ppx_driver, native) = "native/ppx_deriving_make.cmxa"
+  exists_if = "native/ppx_deriving_make.cma"
+)

--- a/packages/ppx_deriving-windows.3.3/files/pkg/build.ml
+++ b/packages/ppx_deriving-windows.3.3/files/pkg/build.ml
@@ -1,0 +1,8 @@
+#!/usr/bin/env ocaml
+#directory "pkg"
+#use "topkg.ml"
+
+let () =
+  Pkg.describe "ppx_deriving" ~builder:`OCamlbuild [
+    Pkg.lib "pkg/META";
+    Pkg.lib ~exts:Exts.module_library "src/ppx_deriving_runtime"; ]

--- a/packages/ppx_deriving-windows.3.3/opam
+++ b/packages/ppx_deriving-windows.3.3/opam
@@ -9,16 +9,24 @@ dev-repo: "https://github.com/whitequark/ppx_deriving.git"
 tags: [ "syntax" ]
 substs: [ "pkg/META" ]
 build: [
-  # If there is no native dynlink, we can't use native builds
-  "ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%"
-                         "native-dynlink=%{ocaml-native-dynlink}%"
+  [ "ocamlbuild" "-just-plugin" "-use-ocamlfind" "-plugin-tags" "package(cppo_ocamlbuild)"]
+  [ "env" "OCAMLFIND_TOOLCHAIN=windows"
+    "ocaml" "pkg/build.ml" "native=true"
+                           "native-dynlink=true" ]
+]
+install: [
+  ["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_deriving.install"]
+  ["ln" "-sf" "%{lib}%/ppx_deriving" "%{prefix}%/windows-sysroot/lib/ppx_deriving/native"]
+]
+remove : [
+  ["rm" "-f" "%{prefix}%/windows-sysroot/lib/ppx_deriving/native"]
+  ["ocamlfind" "-toolchain" "windows" "remove" "ppx_deriving"]
 ]
 depends: [
   "ocaml-windows"
   "ocamlbuild" {build}
   "cppo"       {build & >= "1.2.2"}
-  "ppx_tools"  {>= "4.02.3"}
+  "ppx_tools-windows"  {>= "4.02.3"}
+  "ocaml-windows"
 ]
-install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_deriving.install"]]
-remove: [["ocamlfind" "-toolchain" "windows" "remove" "ppx_deriving"]]
 available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/packages/ppx_deriving-windows.3.3/opam
+++ b/packages/ppx_deriving-windows.3.3/opam
@@ -14,8 +14,8 @@ build: [
                          "native-dynlink=%{ocaml-native-dynlink}%"
 ]
 depends: [
+  "ocaml-windows"
   "ocamlbuild" {build}
-  "ocamlfind"  {build & >= "1.5.4"}
   "cppo"       {build & >= "1.2.2"}
   "ppx_tools"  {>= "4.02.3"}
 ]

--- a/packages/ppx_deriving-windows.3.3/opam
+++ b/packages/ppx_deriving-windows.3.3/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving"
+doc: "https://whitequark.github.io/ppx_deriving"
+bug-reports: "https://github.com/whitequark/ppx_deriving/issues"
+dev-repo: "https://github.com/whitequark/ppx_deriving.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  # If there is no native dynlink, we can't use native builds
+  "ocaml" "pkg/build.ml" "native=%{ocaml-native-dynlink}%"
+                         "native-dynlink=%{ocaml-native-dynlink}%"
+]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.5.4"}
+  "cppo"       {build & >= "1.2.2"}
+  "ppx_tools"  {>= "4.02.3"}
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_deriving.install"]]
+remove: [["ocamlfind" "-toolchain" "windows" "remove" "ppx_deriving"]]
+available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/packages/ppx_deriving-windows.3.3/url
+++ b/packages/ppx_deriving-windows.3.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/whitequark/ppx_deriving/archive/v3.3.tar.gz"
+checksum: "c4a15d783a76912a1244a95aebb5935c"

--- a/packages/ppx_driver-windows.113.33.01+4.03/descr
+++ b/packages/ppx_driver-windows.113.33.01+4.03/descr
@@ -1,0 +1,2 @@
+Feature-full driver for OCaml AST transformers
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_driver-windows.113.33.01+4.03/opam
+++ b/packages/ppx_driver-windows.113.33.01+4.03/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_driver"
+bug-reports: "https://github.com/janestreet/ppx_driver/issues"
+dev-repo: "https://github.com/janestreet/ppx_driver.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" "%{prefix}%/windows-sysroot"]
+  [make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_driver.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_driver"]
+depends: [
+  "ocamlbuild"  {build}
+  "ocamlfind"   {build & >= "1.3.2"}
+  "ocamlbuild"
+  "ppx_core"    {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_optcomp" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_optcomp-windows" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_driver-windows.113.33.01+4.03/opam
+++ b/packages/ppx_driver-windows.113.33.01+4.03/opam
@@ -12,11 +12,11 @@ build: [
 install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_driver.install"]]
 remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_driver"]
 depends: [
+  "ocaml-windows"
   "ocamlbuild"  {build}
-  "ocamlfind"   {build & >= "1.3.2"}
-  "ocamlbuild"
   "ppx_core"    {>= "113.33.00+4.03" & < "113.34.00+4.03"}
   "ppx_optcomp" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_core-windows"    {>= "113.33.00+4.03" & < "113.34.00+4.03"}
   "ppx_optcomp-windows" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_driver-windows.113.33.01+4.03/url
+++ b/packages/ppx_driver-windows.113.33.01+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_driver-113.33.01+4.03.tar.gz"
+checksum: "b2777f18adab3439d08b76e10629e328"

--- a/packages/ppx_fields_conv-windows.113.33.00+4.03/descr
+++ b/packages/ppx_fields_conv-windows.113.33.00+4.03/descr
@@ -1,0 +1,2 @@
+Generation of accessor and iteration functions for ocaml records
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fields_conv-windows.113.33.00+4.03/opam
+++ b/packages/ppx_fields_conv-windows.113.33.00+4.03/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_fields_conv"
+bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_fields_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" "%{prefix}%/windows-sysroot"]
+  [make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_fields_conv.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_fields_conv"]
+depends: [
+  "ocaml-windows"
+  "ocamlbuild"    {build}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_core"      {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_type_conv" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "fieldslib-windows"     {>= "113.24.00" & < "113.25.00"}
+  "ppx_core-windows"      {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_type_conv-windows" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_fields_conv-windows.113.33.00+4.03/url
+++ b/packages/ppx_fields_conv-windows.113.33.00+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_fields_conv-113.33.00+4.03.tar.gz"
+checksum: "b4711219b0ad19fd05916acfc0f1e3a7"

--- a/packages/ppx_optcomp-windows.113.33.01+4.03/descr
+++ b/packages/ppx_optcomp-windows.113.33.01+4.03/descr
@@ -1,0 +1,2 @@
+Optional compilation for OCaml
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_optcomp-windows.113.33.01+4.03/opam
+++ b/packages/ppx_optcomp-windows.113.33.01+4.03/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_optcomp"
+bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+dev-repo: "https://github.com/janestreet/ppx_optcomp.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" "%{prefix}%/windows-sysroot"]
+  [make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_optcomp.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_optcomp"]
+depends: [
+  "ocaml-windows"
+  "ocamlbuild" {build}
+  "ocamlfind"  {build & >= "1.3.2"}
+  "ppx_core"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_tools"  {>= "0.99.3"}
+]
+available: [ ocaml-version >= "4.04.0" ]

--- a/packages/ppx_optcomp-windows.113.33.01+4.03/opam
+++ b/packages/ppx_optcomp-windows.113.33.01+4.03/opam
@@ -14,7 +14,6 @@ remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_optcomp"]
 depends: [
   "ocaml-windows"
   "ocamlbuild" {build}
-  "ocamlfind"  {build & >= "1.3.2"}
   "ppx_core"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}
   "ppx_tools"  {>= "0.99.3"}
 ]

--- a/packages/ppx_optcomp-windows.113.33.01+4.03/url
+++ b/packages/ppx_optcomp-windows.113.33.01+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/janestreet/ppx_optcomp/archive/113.33.01+4.03.tar.gz"
+checksum: "3ed4fade382e98f87b9fee760911aef6"

--- a/packages/ppx_sexp_conv-windows.113.33.01+4.03/descr
+++ b/packages/ppx_sexp_conv-windows.113.33.01+4.03/descr
@@ -1,0 +1,2 @@
+Generation of S-expression conversion functions from type definitions
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_conv-windows.113.33.01+4.03/opam
+++ b/packages/ppx_sexp_conv-windows.113.33.01+4.03/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_sexp_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" "%{prefix}%/windows-sysroot"]
+  [make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_sexp_conv.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_sexp_conv"]
+depends: [
+  "ocaml-windows"
+  "ocamlbuild"    {build}
+  "ocamlfind"     {build & >= "1.3.2"}
+  "ppx_core"      {>= "113.33.01+4.03" & < "113.34.00+4.03"}
+  "ppx_tools"     {>= "0.99.3"}
+  "ppx_type_conv" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_core-windows"      {>= "113.33.01+4.03" & < "113.34.00+4.03"}
+  "ppx_type_conv-windows" {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "sexplib-windows"       {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_sexp_conv-windows.113.33.01+4.03/opam
+++ b/packages/ppx_sexp_conv-windows.113.33.01+4.03/opam
@@ -14,7 +14,6 @@ remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_sexp_conv"]
 depends: [
   "ocaml-windows"
   "ocamlbuild"    {build}
-  "ocamlfind"     {build & >= "1.3.2"}
   "ppx_core"      {>= "113.33.01+4.03" & < "113.34.00+4.03"}
   "ppx_tools"     {>= "0.99.3"}
   "ppx_type_conv" {>= "113.33.00+4.03" & < "113.34.00+4.03"}

--- a/packages/ppx_sexp_conv-windows.113.33.01+4.03/url
+++ b/packages/ppx_sexp_conv-windows.113.33.01+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_sexp_conv-113.33.01+4.03.tar.gz"
+checksum: "0946c58d9a1ba094b2a88e29fe4f6a24"

--- a/packages/ppx_tools-windows.latest/opam
+++ b/packages/ppx_tools-windows.latest/opam
@@ -1,0 +1,9 @@
+opam-version: "1"
+maintainer: "Mauricio Fernandez <mfp@acm.org>"
+install: [
+  ["ln" "-sf" "%{lib}%/ppx_tools" "%{prefix}%/windows-sysroot/lib/ppx_tools"]
+]
+remove: [
+  ["rm" "-f" "%{prefix}%/windows-sysroot/lib/ppx_tools"]
+]
+depends: ["ocaml-windows" "ppx_tools"]

--- a/packages/ppx_type_conv-windows.113.33.01+4.03/descr
+++ b/packages/ppx_type_conv-windows.113.33.01+4.03/descr
@@ -1,0 +1,2 @@
+Support Library for type-driven code generators
+Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_type_conv-windows.113.33.01+4.03/opam
+++ b/packages/ppx_type_conv-windows.113.33.01+4.03/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_type_conv"
+bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
+dev-repo: "https://github.com/janestreet/ppx_type_conv.git"
+license: "Apache-2.0"
+build: [
+  ["./configure" "--prefix" "%{prefix}%/windows-sysroot"]
+  [make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_type_conv.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_type_conv"]
+depends: [
+  "ocamlbuild"   {build}
+  "ocamlfind"    {build & >= "1.3.2"}
+  "ppx_core"     {>= "113.33.01+4.03" & < "113.34.00+4.03"}
+  "ppx_deriving" {>= "3.0" & < "4.0"}
+  "ppx_driver"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+  "ppx_tools"    {>= "0.99.3"}
+  "ppx_deriving-windows" {>= "3.0" & < "4.0"}
+  "ppx_driver-windows"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/ppx_type_conv-windows.113.33.01+4.03/opam
+++ b/packages/ppx_type_conv-windows.113.33.01+4.03/opam
@@ -12,8 +12,8 @@ build: [
 install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "ppx_type_conv.install"]]
 remove: ["ocamlfind" "-toolchain" "windows" "remove" "ppx_type_conv"]
 depends: [
+  "ocaml-windows"
   "ocamlbuild"   {build}
-  "ocamlfind"    {build & >= "1.3.2"}
   "ppx_core"     {>= "113.33.01+4.03" & < "113.34.00+4.03"}
   "ppx_deriving" {>= "3.0" & < "4.0"}
   "ppx_driver"   {>= "113.33.00+4.03" & < "113.34.00+4.03"}

--- a/packages/ppx_type_conv-windows.113.33.01+4.03/url
+++ b/packages/ppx_type_conv-windows.113.33.01+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/ppx_type_conv-113.33.01+4.03.tar.gz"
+checksum: "e55c248967c24b7281d4a423a63a61a4"

--- a/packages/sexplib-windows.113.33.00+4.03/descr
+++ b/packages/sexplib-windows.113.33.00+4.03/descr
@@ -1,0 +1,5 @@
+Library for serializing OCaml values to and from S-expressions
+Part of Jane Street’s Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.

--- a/packages/sexplib-windows.113.33.00+4.03/opam
+++ b/packages/sexplib-windows.113.33.00+4.03/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "https://github.com/janestreet/sexplib.git"
+license: "Apache-2.0"
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" "./configure" "--prefix" prefix]
+  ["ocamlbuild" "-just-plugin"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" make]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "sexplib.install"]]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "sexplib"]
+depends: [
+  "ocamlbuild" {build}
+  "ocaml-windows"
+]
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/sexplib-windows.113.33.00+4.03/url
+++ b/packages/sexplib-windows.113.33.00+4.03/url
@@ -1,0 +1,2 @@
+archive: "https://ocaml.janestreet.com/ocaml-core/113.33/files/sexplib-113.33.00+4.03.tar.gz"
+checksum: "488876d2d4a5490f13eb660af6799bc5"

--- a/packages/stringext-windows.1.4.2/descr
+++ b/packages/stringext-windows.1.4.2/descr
@@ -1,0 +1,5 @@
+Extra string functions for OCaml
+
+Provides a single module named Stringext that provides a grab bag of often used
+but missing string functions from the stdlib. E.g, split, full_split, cut,
+rcut, etc.

--- a/packages/stringext-windows.1.4.2/opam
+++ b/packages/stringext-windows.1.4.2/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer:   "rudi.grinberg@gmail.com"
+authors:      "Rudi Grinberg"
+homepage:     "https://github.com/rgrinberg/stringext"
+bug-reports:  "https://github.com/rgrinberg/stringext/issues"
+license:      "MIT"
+dev-repo:     "https://github.com/rgrinberg/stringext.git"
+
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%/windows-sysroot"
+                                   "--override" "ext_dll" ".dll"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-install"]
+]
+
+remove: [["ocamlfind" "-toolchain" "windows" "remove" "stringext"]]
+
+depends: [
+  "ocaml-windows"
+  "ocamlbuild" {build}
+]
+
+available: [ocaml-version >= "4.00.0"]

--- a/packages/stringext-windows.1.4.2/url
+++ b/packages/stringext-windows.1.4.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/rgrinberg/stringext/archive/v1.4.2.tar.gz"
+checksum: "38385cf57849c8dd0bdd0c8b08f120e7"

--- a/packages/uri-windows.1.9.2/descr
+++ b/packages/uri-windows.1.9.2/descr
@@ -1,0 +1,3 @@
+RFC3986 URI/URL parsing library
+
+RFC3986 URI/URL parsing library

--- a/packages/uri-windows.1.9.2/opam
+++ b/packages/uri-windows.1.9.2/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "https://github.com/mirage/ocaml-uri.git"
+maintainer: "sheets@alum.mit.edu"
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Rudi Grinberg"
+]
+license: "ISC"
+tags: [
+  "url"
+  "uri"
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%/windows-sysroot"
+                                   "--override" "ext_dll" ".dll"]
+  ["ocamlbuild" "-use-ocamlfind" "-just-plugin"]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["env" "OCAMLFIND_TOOLCHAIN=windows"
+   "ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "-toolchain" "windows" "remove" "uri"]
+]
+depends: [
+  "ocaml-windows"
+  "re-windows"
+  "stringext-windows" {>= "1.4.0"}
+  "sexplib-windows"
+  "ppx_sexp_conv-windows"
+  "ocamlbuild" {build}
+]
+available: [ ocaml-version >= "4.02.2" ]

--- a/packages/uri-windows.1.9.2/url
+++ b/packages/uri-windows.1.9.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mirage/ocaml-uri/archive/v1.9.2.tar.gz"
+checksum: "e6dd39352b1b501cb905ef7d198d38f0"


### PR DESCRIPTION
The brings in cohttp and its dependencies which include lots of ppx.  angstrom is also along for the ride.

I'll clean up the commits themselves once the general approach is vetted.  That cleanup will include splitting out the multi-package-affecting commits into per-package commits with appropriate commit messages.

@whitequark Do you have any suggestions for better ppx handling?  This approach (install parallel versions under `windows-sysroot`) seems like a hack.  But I'm not sure how to make a better hack with the tools we have available.

Some general notes:
- ppx_blob and ppx_defer: easy to port over and useful in my code; not required for cohttp
- angstrom: useful in my code and easy to port since cstruct was already required for cohttp
- Everything else is required for cohttp
- ppx_deriving is version 3.3 because of Jane St ppx version constraints.  It's really only providing its runtime library in this package.