### PR TITLE
+ppx_tools_versioned-windows.5.0.1

### DIFF
--- a/packages/ppx_tools_versioned-windows.5.0.1/descr
+++ b/packages/ppx_tools_versioned-windows.5.0.1/descr
@@ -1,0 +1,1 @@
+A variant of ppx_tools based on ocaml-migrate-parsetree

--- a/packages/ppx_tools_versioned-windows.5.0.1/opam
+++ b/packages/ppx_tools_versioned-windows.5.0.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "pierre.boutillier@laposte.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+]
+homepage: "https://github.com/let-def/ppx_tools_versioned"
+bug-reports: "https://github.com/let-def/ppx_tools_versioned/issues"
+license: "MIT"
+tags: "syntax"
+dev-repo: "git://github.com/let-def/ppx_tools_versioned.git"
+build: ["env" "OCAMLFIND_TOOLCHAIN=windows" make "all"]
+install: ["env" "OCAMLFIND_TOOLCHAIN=windows" make "install"]
+remove:
+  ["ocamlfind" "-toolchain" "windows" "remove" "ppx_tools_versioned"]
+depends: [
+  "ocaml-windows"
+  "ocamlfind" {build & >= "1.5.0"}
+  "ocaml-migrate-parsetree-windows" {>= "0.7"}
+]

--- a/packages/ppx_tools_versioned-windows.5.0.1/url
+++ b/packages/ppx_tools_versioned-windows.5.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/let-def/ppx_tools_versioned/archive/5.0.1.tar.gz"
+checksum: "fa26fd27ac77aaf5058c86158b6b2267"


### PR DESCRIPTION
dependency of lwt 3.2.0

I'm not confident with how jbuilder-windows yet so I don't know whether I should add the dependency `"ppx_tools_versioned" {= "5.0.1" }` or not.
I didn't as it is not done by `ocaml-migrate-parsetree-windows`...