### PR TITLE
Fix for ocamlbuild-windows build

### DIFF
--- a/packages/ocamlbuild-windows.0.12.0/opam
+++ b/packages/ocamlbuild-windows.0.12.0/opam
@@ -7,7 +7,7 @@ license: "LGPL-2 with OCaml linking exception"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 dev-repo: "https://github.com/ocaml/ocamlbuild.git"
 build: [
-  [ "sh" "-c" "export PATH=%{prefix}%/windows-sysroot/bin:$PATH && %{make}% -f configure.make all OCAMLBUILD_PREFIX=%{prefix}%/windows-sysroot OCAMLBUILD_BINDIR=%{prefix}%/windows-sysroot/bin OCAMLBUILD_LIBDIR=%{prefix}%/windows-sysroot/lib OCAMLBUILD_MANDIR=%{prefix}%/windows-sysroot/man OCAML_NATIVE=true OCAML_NATIVE_TOOLS=false && %{make}% check-if-preinstalled byte native install-lib-opam"]
+  [ "sh" "-c" "export PATH=\"%{prefix}%/windows-sysroot/bin:$PATH\" && %{make}% -f configure.make all OCAMLBUILD_PREFIX=%{prefix}%/windows-sysroot OCAMLBUILD_BINDIR=%{prefix}%/windows-sysroot/bin OCAMLBUILD_LIBDIR=%{prefix}%/windows-sysroot/lib OCAMLBUILD_MANDIR=%{prefix}%/windows-sysroot/man OCAML_NATIVE=true OCAML_NATIVE_TOOLS=false && %{make}% check-if-preinstalled byte native install-lib-opam"]
 ]
 install: [
   ["opam-installer" "-i" "--prefix" "%{prefix}%/windows-sysroot" "ocamlbuild.install"]


### PR DESCRIPTION
Added quotes around $PATH to avoid issues with spaces in directory names (e.g. in WSL/Bash for Windows).