### PR TITLE
md5sum of jbuilder-windows.1.0+beta16 has changed

### DIFF
--- a/packages/jbuilder-windows.1.0+beta16/url
+++ b/packages/jbuilder-windows.1.0+beta16/url
@@ -1,2 +1,2 @@
 archive: "https://github.com/diml/jbuilder/archive/674548b.tar.gz"
-checksum: "4ee52a1aa973c62245c5510b42e62fab"
+checksum: "5ce14955c1be7ab03f73136a715ddc6d"


### PR DESCRIPTION
I've realised it through https://travis-ci.org/Kappa-Dev/KaSim/jobs/337768157.

I have not idea of why it happened so maybe there is something deeper and this patch isn't the solution...