### PR TITLE
+yojson-windows.1.6.0

### DIFF
--- a/packages/yojson-windows.1.6.0/opam
+++ b/packages/yojson-windows.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "pierre.boutillier@laposte.net"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/ocaml-community/yojson"
+bug-reports: "https://github.com/ocaml-community/yojson/issues"
+dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+doc: "https://ocaml-community.github.io/yojson/"
+build: [
+  ["dune" "build" "-p" "yojson" "-j" jobs "-x" "windows"]
+]
+depends: [
+  "dune" {build}
+  "cppo" {build}
+  "easy-format-windows"
+  "biniou-windows"
+]
+synopsis:
+  "Yojson is an optimized parsing and printing library for the JSON format"
+description: """
+Yojson is an optimized parsing and printing library for the JSON format.
+
+It addresses a few shortcomings of json-wheel including 2x speedup,
+polymorphic variants and optional syntax for tuples and variants.
+
+ydump is a pretty-printing command-line program provided with the
+yojson package.
+
+The program atdgen can be used to derive OCaml-JSON serializers and
+deserializers from type definitions."""
+url {
+  src:
+    "https://github.com/ocaml-community/yojson/releases/download/1.6.0/yojson-1.6.0.tbz"
+  checksum: "md5=8ca16557d3068253cc375452af3bde96"
+}


### PR DESCRIPTION
I did not replace yojson 1.5.0 by yojson 1.6.0 because, according to me, yojson.1.6.0 should be better called yojson.1.99.0. It is a release that prepare incompatible changes to come by still accepting the deprecated stuff but editing tons of warnings asking users to "update to get ready for yojson.2.0".

Therefore, my plan is to keep yojson.1.5.0 as the stable yojson1 version (and to replace yojson.1.6.0 by yojson.2.0.0 when it is released...)