### PR TITLE
Fix #60: `ocamlopt -config` outputs the target `os_type`

### DIFF
--- a/packages/ocaml-windows32.4.07.0/files/config/Makefile.in
+++ b/packages/ocaml-windows32.4.07.0/files/config/Makefile.in
@@ -67,6 +67,7 @@ MKLIB=%{conf-gcc-windows32:prefix}%ar rc $(1) $(2); %{conf-gcc-windows32:prefix}
 ARCH=i386
 MODEL=default
 SYSTEM=mingw
+OCAML_OS_TYPE=Win32
 NATIVECCPROFOPTS=$(BYTECCCOMPOPTS)
 NATIVECCLIBS=$(BYTECCLIBS)
 ASM=%{conf-gcc-windows32:prefix}%as

--- a/packages/ocaml-windows32.4.07.0/files/patches/ocamlopt-config-returns-target-os_type.patch
+++ b/packages/ocaml-windows32.4.07.0/files/patches/ocamlopt-config-returns-target-os_type.patch
@@ -1,0 +1,43 @@
+diff -r -u ocaml-4.07.0/configure ocaml-travail/configure
+--- ocaml-4.07.0/configure	2018-07-10 15:33:25.000000000 +0200
++++ ocaml-travail/configure	2019-04-11 19:20:51.575488976 +0200
+@@ -2130,6 +2130,7 @@
+ config WITH_CPLUGINS "$with_cplugins"
+ config WITH_FPIC "$with_fpic"
+ config TARGET "$target"
++config OCAML_OS_TYPE "$ostype"
+ config HOST "$host"
+ if [ "$ostype" = Cygwin ]; then
+   config DIFF "diff -q --strip-trailing-cr"
+diff -r -u ocaml-4.07.0/Makefile ocaml-travail/Makefile
+--- ocaml-4.07.0/Makefile	2018-07-10 15:33:25.000000000 +0200
++++ ocaml-travail/Makefile	2019-04-11 19:16:02.975501673 +0200
+@@ -363,6 +363,7 @@
+ 	    $(call SUBST,SYSTEM) \
+ 	    $(call SUBST,SYSTHREAD_SUPPORT) \
+ 	    $(call SUBST,TARGET) \
++	    $(call SUBST,OCAML_OS_TYPE) \
+ 	    $(call SUBST,WITH_FRAME_POINTERS) \
+ 	    $(call SUBST,WITH_PROFINFO) \
+ 	    $(call SUBST,WITH_SPACETIME) \
+diff -r -u ocaml-4.07.0/utils/config.mlp ocaml-travail/utils/config.mlp
+--- ocaml-4.07.0/utils/config.mlp	2018-07-10 15:33:25.000000000 +0200
++++ ocaml-travail/utils/config.mlp	2019-04-11 19:17:50.015496964 +0200
+@@ -141,7 +141,7 @@
+ let target = "%%TARGET%%"
+ 
+ let default_executable_name =
+-  match Sys.os_type with
++  match "%%OCAML_OS_TYPE%%" with
+     "Unix" -> "a.out"
+   | "Win32" | "Cygwin" -> "camlprog.exe"
+   | _ -> "camlprog"
+@@ -184,7 +184,7 @@
+   p "ext_asm" ext_asm;
+   p "ext_lib" ext_lib;
+   p "ext_dll" ext_dll;
+-  p "os_type" Sys.os_type;
++  p "os_type" "%%OCAML_OS_TYPE%%";
+   p "default_executable_name" default_executable_name;
+   p_bool "systhread_supported" systhread_supported;
+   p "host" host;

--- a/packages/ocaml-windows32.4.07.0/opam
+++ b/packages/ocaml-windows32.4.07.0/opam
@@ -6,6 +6,7 @@ patches: [
   "patches/avoid-cygwin-specifics.patch"
   "patches/use-host-ocamldoc.patch"
   "patches/no-ocamltest.patch"
+  "patches/ocamlopt-config-returns-target-os_type.patch"
 ]
 substs: [
   "config/Makefile"
@@ -41,7 +42,7 @@ extra-files: [
   ["build.sh" "md5=661e39ae28fb81178637519169313521"]
   ["byterun/caml/s.h" "md5=cea41384207dddbdeb1f662af40bd067"]
   ["byterun/caml/m.h" "md5=04983943424ca21bdad1e6a0e808fdc3"]
-  ["config/Makefile.in" "md5=f1c487d0ccd87c50aa20d0b4ffe34140"]
+  ["config/Makefile.in" "md5=1c759ecb31a405cfa08bc5202cc0cd63"]
   [
     "patches/use-host-ocamlrun-for-stdlib-doc.patch"
     "md5=bb186ecb914bde3a0a356b691ee8b945"
@@ -52,6 +53,10 @@ extra-files: [
   [
     "patches/avoid-cygwin-specifics.patch"
     "md5=ad2c2113ccfee31ac8d31a8683514ea1"
+  ]
+  [
+    "patches/ocamlopt-config-returns-target-os_type.patch"
+    "md5=6aef55b54bd47813545a03ececf25a29"
   ]
 ]
 url {

--- a/packages/ocaml-windows64.4.07.0/files/config/Makefile.in
+++ b/packages/ocaml-windows64.4.07.0/files/config/Makefile.in
@@ -67,6 +67,7 @@ MKLIB=%{conf-gcc-windows64:prefix}%ar rc $(1) $(2); %{conf-gcc-windows64:prefix}
 ARCH=amd64
 MODEL=default
 SYSTEM=mingw64
+OCAML_OS_TYPE=Win32
 NATIVECCPROFOPTS=$(BYTECCCOMPOPTS)
 NATIVECCLIBS=$(BYTECCLIBS)
 ASM=%{conf-gcc-windows64:prefix}%as

--- a/packages/ocaml-windows64.4.07.0/files/patches/ocamlopt-config-returns-target-os_type.patch
+++ b/packages/ocaml-windows64.4.07.0/files/patches/ocamlopt-config-returns-target-os_type.patch
@@ -1,0 +1,43 @@
+diff -r -u ocaml-4.07.0/configure ocaml-travail/configure
+--- ocaml-4.07.0/configure	2018-07-10 15:33:25.000000000 +0200
++++ ocaml-travail/configure	2019-04-11 19:20:51.575488976 +0200
+@@ -2130,6 +2130,7 @@
+ config WITH_CPLUGINS "$with_cplugins"
+ config WITH_FPIC "$with_fpic"
+ config TARGET "$target"
++config OCAML_OS_TYPE "$ostype"
+ config HOST "$host"
+ if [ "$ostype" = Cygwin ]; then
+   config DIFF "diff -q --strip-trailing-cr"
+diff -r -u ocaml-4.07.0/Makefile ocaml-travail/Makefile
+--- ocaml-4.07.0/Makefile	2018-07-10 15:33:25.000000000 +0200
++++ ocaml-travail/Makefile	2019-04-11 19:16:02.975501673 +0200
+@@ -363,6 +363,7 @@
+ 	    $(call SUBST,SYSTEM) \
+ 	    $(call SUBST,SYSTHREAD_SUPPORT) \
+ 	    $(call SUBST,TARGET) \
++	    $(call SUBST,OCAML_OS_TYPE) \
+ 	    $(call SUBST,WITH_FRAME_POINTERS) \
+ 	    $(call SUBST,WITH_PROFINFO) \
+ 	    $(call SUBST,WITH_SPACETIME) \
+diff -r -u ocaml-4.07.0/utils/config.mlp ocaml-travail/utils/config.mlp
+--- ocaml-4.07.0/utils/config.mlp	2018-07-10 15:33:25.000000000 +0200
++++ ocaml-travail/utils/config.mlp	2019-04-11 19:17:50.015496964 +0200
+@@ -141,7 +141,7 @@
+ let target = "%%TARGET%%"
+ 
+ let default_executable_name =
+-  match Sys.os_type with
++  match "%%OCAML_OS_TYPE%%" with
+     "Unix" -> "a.out"
+   | "Win32" | "Cygwin" -> "camlprog.exe"
+   | _ -> "camlprog"
+@@ -184,7 +184,7 @@
+   p "ext_asm" ext_asm;
+   p "ext_lib" ext_lib;
+   p "ext_dll" ext_dll;
+-  p "os_type" Sys.os_type;
++  p "os_type" "%%OCAML_OS_TYPE%%";
+   p "default_executable_name" default_executable_name;
+   p_bool "systhread_supported" systhread_supported;
+   p "host" host;

--- a/packages/ocaml-windows64.4.07.0/opam
+++ b/packages/ocaml-windows64.4.07.0/opam
@@ -7,6 +7,7 @@ patches: [
   "patches/avoid-cygwin-specifics.patch"
   "patches/use-host-ocamldoc.patch"
   "patches/no-ocamltest.patch"
+  "patches/ocamlopt-config-returns-target-os_type.patch"
 ]
 substs: [
   "config/Makefile"
@@ -44,7 +45,7 @@ extra-files: [
   ["build.sh" "md5=6c947146f128b8321e4deba61aded445"]
   ["byterun/caml/s.h" "md5=cea41384207dddbdeb1f662af40bd067"]
   ["byterun/caml/m.h" "md5=dc60b790626b4d8d8c6769f4b8013ca2"]
-  ["config/Makefile.in" "md5=fb24a8ea27990d202e3b12d337b781aa"]
+  ["config/Makefile.in" "md5=3b43d7043f360ba045afa0000d308801"]
   [
     "patches/use-host-ocamlrun-for-stdlib-doc.patch"
     "md5=bb186ecb914bde3a0a356b691ee8b945"
@@ -56,6 +57,10 @@ extra-files: [
   [
     "patches/avoid-cygwin-specifics.patch"
     "md5=ad2c2113ccfee31ac8d31a8683514ea1"
+  ]
+  [
+    "patches/ocamlopt-config-returns-target-os_type.patch"
+    "md5=6aef55b54bd47813545a03ececf25a29"
   ]
 ]
 url {


### PR DESCRIPTION
I'm in the process of discussing how to upstream that but in the meantime I would like to apply the patch for 4.07 here already...

I successfully compiled lwt.4.2.1 with this patch (MR will follow this one)

The patch does not touch `Sys.os_type`. It only hard wires in the output of `ocamlopt -config` its configure time value...