### PR TITLE
Updated batteries-windows from 2.8.0 -> 2.9.0 to allow compilation with ocaml 4.07.0 

### DIFF
--- a/packages/batteries-windows.2.8.0/opam
+++ b/packages/batteries-windows.2.8.0/opam
@@ -1,30 +1,14 @@
 opam-version: "2.0"
 name: "batteries-windows"
+version: "2.8.0"
+synopsis: "A community-maintained standard library extension"
 maintainer: "thelema314@gmail.com"
 authors: "OCaml batteries-included team"
-homepage: "http://batteries.forge.ocamlcore.org/"
-bug-reports: "https://github.com/ocaml-batteries-team/batteries-included/issues"
-dev-repo:
-  "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 license: "LGPL-2.1+ with OCaml linking exception"
+homepage: "http://batteries.forge.ocamlcore.org/"
 doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
-build: [
-  ["env" "OCAMLFIND_TOOLCHAIN=windows"
-   "ocaml" "setup.ml" "-configure" "--prefix" "%{prefix}%/windows-sysroot"
-                                   "--override" "ext_dll" ".dll"]
-  ["ocamlbuild" "-use-ocamlfind" "-just-plugin"]
-  ["ocamlbuild" "-no-links" "-use-ocamlfind" "build/prefilter.byte" "build/mkconf.byte"]
-  ["env" "OCAMLFIND_TOOLCHAIN=windows"
-   make "all"]
-]
-install: [
-  ["env" "OCAMLFIND_TOOLCHAIN=windows"
-   make "install"]
-]
-remove: [
-  ["env" "OCAMLFIND_TOOLCHAIN=windows"
-   "ocamlfind" "remove" "batteries"]
-]
+bug-reports:
+  "https://github.com/ocaml-batteries-team/batteries-included/issues"
 depends: [
   "ocaml" {>= "3.12.1" & < "4.07.0"}
   "ocamlfind" {>= "1.5.3"}
@@ -36,7 +20,35 @@ depends: [
   "num-windows"
   "ocaml-windows"
 ]
-synopsis: "a community-maintained standard library extension"
+build: [
+  [
+    "env"
+    "OCAMLFIND_TOOLCHAIN=windows"
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--prefix"
+    "%{prefix}%/windows-sysroot"
+    "--override"
+    "ext_dll"
+    ".dll"
+  ]
+  ["ocamlbuild" "-use-ocamlfind" "-just-plugin"]
+  [
+    "ocamlbuild"
+    "-no-links"
+    "-use-ocamlfind"
+    "build/prefilter.byte"
+    "build/mkconf.byte"
+  ]
+  ["env" "OCAMLFIND_TOOLCHAIN=windows" make "all"]
+]
+install: ["env" "OCAMLFIND_TOOLCHAIN=windows" make "install"]
+remove: [
+  "env" "OCAMLFIND_TOOLCHAIN=windows" "ocamlfind" "remove" "batteries"
+]
+dev-repo:
+  "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src:
     "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.8.0/batteries-2.8.0.tar.gz"

--- a/packages/batteries-windows.2.9.0/opam
+++ b/packages/batteries-windows.2.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "batteries-windows"
-version: "2.8.0"
+version: "2.9.0"
 synopsis: "A community-maintained standard library extension"
 maintainer: "thelema314@gmail.com"
 authors: "OCaml batteries-included team"
@@ -10,8 +10,8 @@ doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
 bug-reports:
   "https://github.com/ocaml-batteries-team/batteries-included/issues"
 depends: [
-  "ocaml" {>= "3.12.1" & < "4.07.0"}
-  "ocamlfind" {>= "1.5.3"}
+  "ocaml" {>= "4.00.0" & < "4.08.0"}
+  "ocamlfind" {build & >= "1.5.3"}
   "ocamlbuild" {build}
   "qtest" {with-test & >= "2.5"}
   "qcheck" {with-test & >= "0.6"}
@@ -51,6 +51,6 @@ dev-repo:
   "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src:
-    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.8.0/batteries-2.8.0.tar.gz"
-  checksum: "md5=2d9a811dcb47bae9f1159676d880a46b"
+    "https://github.com/ocaml-batteries-team/batteries-included/releases/download/v2.9.0/batteries-2.9.0.tar.gz"
+  checksum: "md5=482adf4d08e90cc215dbaee0314a84fa"
 }


### PR DESCRIPTION
Retry for: https://github.com/ocaml-cross/opam-cross-windows/pull/100

Sorry for the error: I did refactor my repository clone, with branches for each of my PR without realizing it would impact the opened PR.

Best regards