### PR TITLE
Have flexdll store symbol alias without __nm_ prefix

### DIFF
--- a/packages/flexdll-windows.0.37/files/patches/also-store-symbol-aliases-without-__nm_-prefix.patch
+++ b/packages/flexdll-windows.0.37/files/patches/also-store-symbol-aliases-without-__nm_-prefix.patch
@@ -1,0 +1,30 @@
+--- a/coff.ml
++++ b/coff.ml
+@@ -125,6 +125,12 @@ end = struct
+     r := Int32.of_int (length b)
+ end
+
++(* [starts_with ~what str]
++   @return true if [str] starts with [what] *)
++let starts_with ~what str =
++  let what_len = String.length what in
++  what_len <= String.length str &&
++  String.sub str 0 what_len = what
+
+ (* Internal representation of COFF object files *)
+
+@@ -758,9 +764,12 @@ module Coff = struct
+     let a = ref [] in
+     List.iter
+       (fun s ->
+-         match s.extra_info with
++         (match s.extra_info with
+            | `Alias s' -> a := (s.sym_name,s'.sym_name) :: !a
+-           | _ -> ()
++           | _ -> ());
++         if starts_with ~what:"__nm_" s.sym_name then
++           a := (String.sub s.sym_name 5 (String.length s.sym_name - 5),
++                s.sym_name) :: !a
+       )
+       x.symbols;
+     !a

--- a/packages/flexdll-windows.0.37/opam
+++ b/packages/flexdll-windows.0.37/opam
@@ -3,6 +3,7 @@ maintainer: "whitequark@whitequark.org"
 substs: [
   "version.ml"
 ]
+patches: ["patches/also-store-symbol-aliases-without-__nm_-prefix.patch"]
 build: [
   ["touch" "Compat.ml"]
   ["sh" "-c" "cat Compat402.ml >> Compat.ml"] {ocaml:compiler < "4.02.0"}
@@ -62,6 +63,7 @@ synopsis:
 extra-files: [
   ["version.ml.in" "md5=f1bb53b9442eeda71d4963c02bf9fa84"]
   ["flexdll-windows.install" "md5=0c2e036b485aab29b553ddf4d7677cd7"]
+  ["patches/also-store-symbol-aliases-without-__nm_-prefix.patch" "md5=b67613e39fde603b43eb0d421d09eaad"]
 ]
 url {
   src: "https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz"


### PR DESCRIPTION
This is not really a pull request (except if it is found that it is useful).

I had to patch flexdll this way in order to have one project of mine to compile.

This is a project with a binding to C++ DLLs.
flexdll does not find some of the expected symbols, but there are found with "__nm_" prepended.
I have no idea why.
My patch is just adding an alias without this prefx to the symbol found by flexdll.

Any idea where this problem comes from?

Best regards