### PR TITLE
Fix (fatal) warning when building ocaml-windows64

### DIFF
--- a/packages/ocaml-windows64/ocaml-windows64.4.08.0/files/patches/ostype-fix.patch
+++ b/packages/ocaml-windows64/ocaml-windows64.4.08.0/files/patches/ostype-fix.patch
@@ -58,6 +58,15 @@ diff --git a/stdlib/sys.mlp b/stdlib/sys.mlp
 index 5d997e8ad..f1196504e 100644
 --- a/stdlib/sys.mlp
 +++ b/stdlib/sys.mlp
+@@ -24,7 +24,7 @@ type backend_type =
+   | Other of string
+ (* System interface *)
+ 
+-external get_config: unit -> string * int * bool = "caml_sys_get_config"
++(*external get_config: unit -> string * int * bool = "caml_sys_get_config"*)
+ external get_argv: unit -> string * string array = "caml_sys_get_argv"
+ external big_endian : unit -> bool = "%big_endian"
+ external word_size : unit -> int = "%word_size"
 @@ -36,7 +36,7 @@ external cygwin : unit -> bool = "%ostype_cygwin"
  external get_backend_type : unit -> backend_type = "%backend_type"
 

--- a/packages/ocaml-windows64/ocaml-windows64.4.08.0/opam
+++ b/packages/ocaml-windows64/ocaml-windows64.4.08.0/opam
@@ -44,7 +44,7 @@ extra-files: [
   ["Makefile.cross.in" "md5=239f0730dc9614f270d240bc942bea3a"]
   ["patches/use-host-ocamldoc.patch" "md5=630690f2185fc50c51847cd74b42e2d1"]
   ["patches/use-host-ocamlrun.patch" "md5=64ab0e21a5071f790a7babf4f92bf954"]
-  ["patches/ostype-fix.patch" "md5=f2ca15a410a6ab1d7b1bd142cccddccf"]
+  ["patches/ostype-fix.patch" "md5=df68c8623e2645e941c922ca81fe076e"]
   ["patches/no-ocamltest.patch" "md5=f1a2006f053f3d195c03f5b8cf4fba31"]
   [
     "patches/avoid-cygwin-specifics.patch"


### PR DESCRIPTION
It was triggered by a value becoming unused because of the patch (and -warn-error A in stdlib/)