### PR TITLE
Add fileutils.

### DIFF
--- a/packages/fileutils-windows/fileutils-windows.0.6.1/opam
+++ b/packages/fileutils-windows/fileutils-windows.0.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
 authors: [ "Sylvain Le Gall" ]
 homepage: "https://github.com/gildor478/ocaml-fileutils"
 license: "LGPL-2.1 with OCaml linking exception"
@@ -9,8 +9,6 @@ doc: "https://gildor478.github.io/ocaml-fileutils/"
 
 build: [
   ["dune" "build" "-p" "fileutils" "-j" jobs "-x" "windows"]
-  ["dune" "runtest" "-p" "fileutils" "-j" jobs] {with-test}
-  ["dune" "build" "@doc" "-p" "fileutils" "-j" jobs] {with-doc}
 ]
 depends: [
   "ocaml-windows" {>= "4.03"}

--- a/packages/fileutils-windows/fileutils-windows.0.6.1/opam
+++ b/packages/fileutils-windows/fileutils-windows.0.6.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ocaml-fileutils"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/gildor478/ocaml-fileutils.git"
+bug-reports: "https://github.com/gildor478/ocaml-fileutils/issues"
+doc: "https://gildor478.github.io/ocaml-fileutils/"
+
+build: [
+  ["dune" "build" "-p" "fileutils" "-j" jobs "-x" "windows"]
+  ["dune" "runtest" "-p" "fileutils" "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" "fileutils" "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml-windows" {>= "4.03"}
+  "base-unix"
+  "base-bytes"
+  "stdlib-shims-windows"
+  "dune" {>= "1.11.0"}
+  "ounit" {with-test & >= "2.0.0"}
+]
+synopsis: "API to manipulate files (POSIX like) and filenames"
+description: """
+This library provides an API to perform POSIX like operations on files like:
+
+- mv
+- cp
+- rm
+- mkdir
+- touch
+- which...
+
+It also providesa module to manipulate abstract filenames:
+
+- classification
+- make_relative: made a filename relative to another
+- make_absolute
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-fileutils/releases/download/v0.6.1/fileutils-v0.6.1.tbz"
+  checksum: [
+    "sha256=458a540eb8e01be1a13e0e71ba6206c5e36635046e696aeb37e0848a14a5375d"
+    "sha512=11693d51b2dd5ff4d955d9e1843d758f63e9e0690c1a3b9c31709e052f3cc7dcb9fd1fd7e20baabe1ecae750f8fde9e762b1097b72ff2f0f5d5afbc6fba680f9"
+  ]
+}
+


### PR DESCRIPTION
From my quick test, installing with `opam install fileutils-windows`, compiling a program like `let () = FileUtil.ls "." |> List.iter print_endline` with `ocamlfind -toolchain windows ocamlopt -package fileutils -linkpkg -o test ./test.ml`, and running `wine ./test.exe` works correctly.

Hope I haven't messed anything up, this is first time I make a cross-version of a package.

Fixes #121 