### PR TITLE
Add lua-ml-windows

### DIFF
--- a/packages/lua-ml-windows/lua-ml-windows.0.9.1/opam
+++ b/packages/lua-ml-windows/lua-ml-windows.0.9.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>"
+  "Christian Lindig <lindig@gmail.com>"
+]
+license: "Two-clause BSD"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+depends: [
+  "ocaml-windows" {>= "4.07"}
+  "ocamlbuild"
+  "ocamlfind"
+  "opam-installer" {build}
+]
+build: [
+  "env" "OCAMLFIND_TOOLCHAIN=windows"
+  make "lib"
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "lua-ml.install"]]
+url {
+  src: "https://github.com/lindig/lua-ml/archive/0.9.1.tar.gz"
+  checksum: [
+    "md5=1010207b8c419a7b95a927d0d56c9171"
+    "sha512=5cb56cd96dbfae42835b3f10f275753685575472ace518e351e62e50a01c07a510203be21644fd3429680b926ecd9905d4dca1e101b762c442f7c6dc00b0f0ae"
+  ]
+}

--- a/packages/lua-ml-windows/lua-ml-windows.0.9/files/use-ocamlfind.patch
+++ b/packages/lua-ml-windows/lua-ml-windows.0.9/files/use-ocamlfind.patch
@@ -1,0 +1,17 @@
+diff --git a/Makefile b/Makefile
+index d33e8a6..bb9f902 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,10 +5,10 @@ all: lib example
+ 
+ lib:
+ 	make -C src all
+-	$(OCB) -I src src/lua-std.cmxa src/lua-std.cma src/lua-std.cmxs
++	$(OCB) -use-ocamlfind -I src src/lua-std.cmxa src/lua-std.cma src/lua-std.cmxs
+ 
+ example:
+-	$(OCB) -I src -I example example/luaclient.native
++	$(OCB) -use-ocamlfind -I src -I example example/luaclient.native
+ 
+ clean:
+ 	make -C src clean

--- a/packages/lua-ml-windows/lua-ml-windows.0.9/opam
+++ b/packages/lua-ml-windows/lua-ml-windows.0.9/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>" "Christian Lindig <lindig@gmail.com>"
+]
+license: "Two-clause BSD"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+dev-repo: "git+https://github.com/lindig/lua-ml.git"
+depends: [
+  "ocaml-windows" {>= "4.07"}
+  "ocamlbuild" {build}
+  "opam-installer" {build}
+]
+patches: [
+  "use-ocamlfind.patch"
+]
+build: [
+  "env" "OCAMLFIND_TOOLCHAIN=windows"
+  make "lib"
+]
+install: [["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "lua-ml.install"]]
+extra-files: [
+  ["use-ocamlfind.patch" "md5=dded0ba4826163e803ec95bbdc3e6316"]
+]
+url {
+  src: "https://github.com/lindig/lua-ml/archive/0.9.zip"
+  checksum: [
+    "md5=fc6537165afb3c6d702b9ae9aeeab01d"
+    "sha512=e8a841dd03256d29eb22868c5cb317db34cfb3de54037605a88812ce4a2d2600de35579af7b627f06c32583510b72e7e02da4bed212658af1edd454a767a1aa7"
+  ]
+}


### PR DESCRIPTION
While I'm technically in position to push the `ocamlbuild -use-ocamlfind` to lua-ml's upstream, I chose to make opam apply a patch due to performance impact of that option.

Eventually we'll switch it to dune and hacks will not be needed anymore.