### PR TITLE
Fix unusable dune-configurator-windows 2.5.1

### DIFF
--- a/packages/dune-configurator-windows/dune-configurator-windows.2.5.1/opam
+++ b/packages/dune-configurator-windows/dune-configurator-windows.2.5.1/opam
@@ -31,6 +31,8 @@ build: [
     "dune-configurator"
     "-j"
     jobs
+    "-x"
+    "windows"
     "@install"
     "@doc" {with-doc}
   ]


### PR DESCRIPTION
Its build command is missing `-x windows`, so it builds, but doesn't produce a windows version, so nothing can be built against it.