### PR TITLE
+core-windows.v0.16.1

### DIFF
--- a/packages/base-windows/base-windows.v0.16.3/opam
+++ b/packages/base-windows/base-windows.v0.16.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "base" "-j" jobs "-x" "windows"]
+]
+depends: [
+  "ocaml-windows"             {>= "4.14.0"}
+  "sexplib0"          {>= "v0.16" & < "v0.17"}
+  "sexplib0-windows"          {>= "v0.16" & < "v0.17"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+  "dune-configurator-windows"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.16.3.tar.gz"
+  checksum: [
+    "md5=04572fc23a4651604cfcab83f720cb4c"
+    "sha512=69380ed392faf4495459f97f70a10a6959fce71d2e6ba093472fc272141646307fd7872407de855dfa48ef0435f6587eae5aa50f4a67eac40a9e1946d0c3c070"
+  ]
+}

--- a/packages/base_bigstring-windows/base_bigstring-windows.v0.16.0/opam
+++ b/packages/base_bigstring-windows/base_bigstring-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base_bigstring"
+bug-reports: "https://github.com/janestreet/base_bigstring/issues"
+dev-repo: "git+https://github.com/janestreet/base_bigstring.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_bigstring/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "base_bigstring" "-j" jobs "-x" "windows"]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "int_repr-windows" {>= "v0.16" & < "v0.17"}
+  "ppx_jane" {>= "v0.16" & < "v0.17"}
+  "ppx_jane-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+]
+synopsis: "String type based on [Bigarray], for use in I/O and C-bindings"
+description: "
+String type based on [Bigarray], for use in I/O and C-bindings.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/base_bigstring-v0.16.0.tar.gz"
+checksum: "sha256=19fcbf8fa1fa557d513679413a9087e4ff1cb846cef1e8a78eaffb293fa926c3"
+}

--- a/packages/base_quickcheck-windows/base_quickcheck-windows.v0.16.0/opam
+++ b/packages/base_quickcheck-windows/base_quickcheck-windows.v0.16.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base_quickcheck"
+bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
+dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "base_quickcheck" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"             {>= "4.14.0"}
+  "base-windows"              {>= "v0.16" & < "v0.17"}
+  "ppx_base"          {>= "v0.16" & < "v0.17"}
+  "ppx_base-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_fields_conv"   {>= "v0.16" & < "v0.17"}
+  "ppx_fields_conv-windows"   {>= "v0.16" & < "v0.17"}
+  "ppx_let"           {>= "v0.16" & < "v0.17"}
+  "ppx_let-windows"           {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message"  {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message-windows"  {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_value"    {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_value-windows"    {>= "v0.16" & < "v0.17"}
+  "splittable_random-windows" {>= "v0.16" & < "v0.17"}
+  "dune"              {>= "2.0.0"}
+  "ppxlib"            {>= "0.28.0"}
+  "ppxlib-windows"            {>= "0.28.0"}
+]
+synopsis: "Randomized testing framework, designed for compatibility with Base"
+description: "
+Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,
+with support for built-in types as well as types provided by Base.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/base_quickcheck-v0.16.0.tar.gz"
+checksum: "sha256=88f80a75d224ceed33d0f891e6bb931979ec24397871b3347b8be22ef96d2e7e"
+}

--- a/packages/bin_prot-windows/bin_prot-windows.v0.16.0/opam
+++ b/packages/bin_prot-windows/bin_prot-windows.v0.16.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/bin_prot"
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "git+https://github.com/janestreet/bin_prot.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "bin_prot" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"              {>= "4.14.0"}
+  "base-windows"               {>= "v0.16" & < "v0.17"}
+  "ppx_compare"        {>= "v0.16" & < "v0.17"}
+  "ppx_compare-windows"        {>= "v0.16" & < "v0.17"}
+  "ppx_custom_printf"  {>= "v0.16" & < "v0.17"}
+  "ppx_custom_printf-windows"  {>= "v0.16" & < "v0.17"}
+  "ppx_fields_conv"    {>= "v0.16" & < "v0.17"}
+  "ppx_fields_conv-windows"    {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"        {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp-windows"        {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv"      {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_stable_witness" {>= "v0.16" & < "v0.17"}
+  "ppx_stable_witness-windows" {>= "v0.16" & < "v0.17"}
+  "ppx_variants_conv"  {>= "v0.16" & < "v0.17"}
+  "ppx_variants_conv-windows"  {>= "v0.16" & < "v0.17"}
+  "dune"               {build & >= "2.0.0"}
+]
+depopts: [
+  "mirage-xen-ocaml"
+]
+synopsis: "A binary protocol generator"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/bin_prot-v0.16.0.tar.gz"
+checksum: "sha256=3ede8089d809186ba2bc7ade49d814c6d60e0414c2ba075807eaeb05d1d0a2f1"
+}

--- a/packages/core-windows/core-windows.v0.16.1/files/patches/no-endian-header.patch
+++ b/packages/core-windows/core-windows.v0.16.1/files/patches/no-endian-header.patch
@@ -1,0 +1,12 @@
+diff --git a/src/bigstring_stubs.c b/src/bigstring_stubs.c
+index ebf54a9..6e81175 100644
+--- a/core/src/bigstring_stubs.c
++++ b/core/src/bigstring_stubs.c
+@@ -31,6 +31,7 @@
+ #define bswap_64 swap64
+ #elif __CYGWIN__
+ #include <endian.h>
++#elif defined(__MINGW32__)
+ #else
+ #include <sys/types.h>
+ #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)

--- a/packages/core-windows/core-windows.v0.16.1/opam
+++ b/packages/core-windows/core-windows.v0.16.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "git+https://github.com/janestreet/core.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html"
+license: "MIT"
+patches: [
+  "patches/no-endian-header.patch"
+]
+build: [
+  ["dune" "build" "-p" "core" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"               {>= "4.14.0"}
+  "base-windows"                {>= "v0.16" & < "v0.17"}
+  "base_bigstring-windows"      {>= "v0.16" & < "v0.17"}
+  "base_quickcheck-windows"     {>= "v0.16" & < "v0.17"}
+  "bin_prot-windows"            {>= "v0.16" & < "v0.17"}
+  "fieldslib-windows"           {>= "v0.16" & < "v0.17"}
+  "jane-street-headers-windows" {>= "v0.16" & < "v0.17"}
+  "jst-config-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_assert"          {>= "v0.16" & < "v0.17"}
+  "ppx_assert-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_base"            {>= "v0.16" & < "v0.17"}
+  "ppx_base-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_hash"            {>= "v0.16" & < "v0.17"}
+  "ppx_hash-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test"     {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_jane"            {>= "v0.16" & < "v0.17"}
+  "ppx_jane-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"         {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp-windows"         {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv"       {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows"       {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message"    {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message-windows"    {>= "v0.16" & < "v0.17"}
+  "sexplib-windows"             {>= "v0.16" & < "v0.17"}
+  "splittable_random-windows"   {>= "v0.16" & < "v0.17"}
+  "stdio-windows"               {>= "v0.16" & < "v0.17"}
+  "time_now-windows"            {>= "v0.16" & < "v0.17"}
+  "typerep-windows"             {>= "v0.16" & < "v0.17"}
+  "variantslib-windows"         {>= "v0.16" & < "v0.17"}
+  "dune"                {>= "2.0.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+This is the system-independent part of Core. Unix-specific parts were moved to [core-unix].
+"
+url {
+  src: "https://github.com/janestreet/core/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=98b40c39c9be584c22a48d40ed3ffe57"
+    "sha512=5f9f4400b6e42b74ffd57223cb67884368d324739565bbb20162547ede8bd6d0ece3cc265503b674829f9cf373784e8036d4c73e26e9196aa5446de69b63e181"
+  ]
+}

--- a/packages/core_kernel-windows/core_kernel-windows.v0.16.0/opam
+++ b/packages/core_kernel-windows/core_kernel-windows.v0.16.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/core_kernel"
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "git+https://github.com/janestreet/core_kernel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "core_kernel" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"        {>= "4.14.0"}
+  "base-windows"         {>= "v0.16" & < "v0.17"}
+  "core-windows"         {>= "v0.16" & < "v0.17"}
+  "int_repr-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_jane"     {>= "v0.16" & < "v0.17"}
+  "ppx_jane-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"  {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp-windows"  {>= "v0.16" & < "v0.17"}
+  "base-threads"
+  "dune"         {>= "2.0.0"}
+]
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+Core_kernel is the system-independent part of Core.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_kernel-v0.16.0.tar.gz"
+checksum: "sha256=e37370bad978cfb71fdaf2b1a25ab1506b98ef0b91e0dbd189ffd9d853245ce2"
+}

--- a/packages/fieldslib-windows/fieldslib-windows.v0.16.0/opam
+++ b/packages/fieldslib-windows/fieldslib-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/fieldslib"
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "git+https://github.com/janestreet/fieldslib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "fieldslib" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "4.14.0"}
+  "base-windows"  {>= "v0.16" & < "v0.17"}
+  "dune"  {>= "2.0.0"}
+]
+synopsis: "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/fieldslib-v0.16.0.tar.gz"
+checksum: "sha256=2cc5954259e71a747dfaad0e86bfe32c04dca35e83372dbcdeefb08c6059b2f1"
+}

--- a/packages/int_repr-windows/int_repr-windows.v0.16.0/opam
+++ b/packages/int_repr-windows/int_repr-windows.v0.16.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/int_repr"
+bug-reports: "https://github.com/janestreet/int_repr/issues"
+dev-repo: "git+https://github.com/janestreet/int_repr.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/int_repr/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "int_repr" "-j" jobs "-x" "windows"]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_jane" {>= "v0.16" & < "v0.17"}
+  "ppx_jane-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+]
+synopsis: "Integers of various widths"
+description: "
+Integers of various widths.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/int_repr-v0.16.0.tar.gz"
+checksum: "sha256=132f56262ffee171ff81162460c7132ac366f0295a23801795385c3620b6f076"
+}

--- a/packages/jane-street-headers-windows/jane-street-headers-windows.v0.16.0/opam
+++ b/packages/jane-street-headers-windows/jane-street-headers-windows.v0.16.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/jane-street-headers"
+bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
+dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jane-street-headers/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "jane-street-headers" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune"  {>= "2.0.0"}
+  "ocaml-windows"
+]
+synopsis: "Jane Street C header files"
+description: "
+C header files shared between the various Jane Street packages
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/jane-street-headers-v0.16.0.tar.gz"
+checksum: "sha256=876d409feeb495487b10010fb601c64829d2aa15f1b156b704ec141337d360ea"
+}

--- a/packages/jst-config-windows/jst-config-windows.v0.16.0/opam
+++ b/packages/jst-config-windows/jst-config-windows.v0.16.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/jst-config"
+bug-reports: "https://github.com/janestreet/jst-config/issues"
+dev-repo: "git+https://github.com/janestreet/jst-config.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jst-config/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "jst-config" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"             {>= "4.14.0"}
+  "base-windows"              {>= "v0.16" & < "v0.17"}
+  "ppx_assert"        {>= "v0.16" & < "v0.17"}
+  "ppx_assert-windows"        {>= "v0.16" & < "v0.17"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+  "dune-configurator-windows"
+]
+synopsis: "Compile-time configuration for Jane Street libraries"
+description: "
+Defines compile-time constants used in Jane Street libraries such as Base, Core, and
+Async.
+
+This package has an unstable interface; it is intended only to share configuration between
+different packages from Jane Street. Future updates may not be backward-compatible, and we
+do not recommend using this package directly.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/jst-config-v0.16.0.tar.gz"
+checksum: "sha256=faead56d8582868cdc099ad54f9bae059cc48710b724600cc64013e73c14d95b"
+}

--- a/packages/parsexp-windows/parsexp-windows.v0.16.0/opam
+++ b/packages/parsexp-windows/parsexp-windows.v0.16.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/parsexp"
+bug-reports: "https://github.com/janestreet/parsexp/issues"
+dev-repo: "git+https://github.com/janestreet/parsexp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "parsexp" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "sexplib0-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+]
+synopsis: "S-expression parsing library"
+description: "
+This library provides generic parsers for parsing S-expressions from
+strings or other medium.
+
+The library is focused on performances but still provide full generic
+parsers that can be used with strings, bigstrings, lexing buffers,
+character streams or any other sources effortlessly.
+
+It provides three different class of parsers:
+- the normal parsers, producing [Sexp.t] or [Sexp.t list] values
+- the parsers with positions, building compact position sequences so
+  that one can recover original positions in order to report properly
+  located errors at little cost
+- the Concrete Syntax Tree parsers, produce values of type
+  [Parsexp.Cst.t] which record the concrete layout of the s-expression
+  syntax, including comments
+
+This library is portable and doesn't provide IO functions. To read
+s-expressions from files or other external sources, you should use
+parsexp_io.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/parsexp-v0.16.0.tar.gz"
+checksum: "sha256=b6e2572c8e6191a85cb8f9c3276ed87fe00522c81ba7a268179fb08185e55e12"
+}

--- a/packages/ppx_assert-windows/ppx_assert-windows.v0.16.0/opam
+++ b/packages/ppx_assert-windows/ppx_assert-windows.v0.16.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_assert"
+bug-reports: "https://github.com/janestreet/ppx_assert/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_assert.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_assert/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_assert" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "4.14.0"}
+  "base"          {>= "v0.16" & < "v0.17"}
+  "base-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_cold"      {>= "v0.16" & < "v0.17"}
+  "ppx_cold-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_compare"   {>= "v0.16" & < "v0.17"}
+  "ppx_compare-windows"   {>= "v0.16" & < "v0.17"}
+  "ppx_here"      {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows" {>= "v0.16" & < "v0.17"}
+  "dune"          {>= "2.0.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+synopsis: "Assert-like extension nodes that raise useful errors on failure"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_assert-v0.16.0.tar.gz"
+checksum: "sha256=57dc6e241827eb1d5112c958f2f682ddd0addf5a8e9d589f5361ec2669883fd5"
+}

--- a/packages/ppx_base-windows/ppx_base-windows.v0.16.0/opam
+++ b/packages/ppx_base-windows/ppx_base-windows.v0.16.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_base"
+bug-reports: "https://github.com/janestreet/ppx_base/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_base" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "4.14.0"}
+  "ppx_cold"      {>= "v0.16" & < "v0.17"}
+  "ppx_cold-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_compare"   {>= "v0.16" & < "v0.17"}
+  "ppx_compare-windows"   {>= "v0.16" & < "v0.17"}
+  "ppx_enumerate" {>= "v0.16" & < "v0.17"}
+  "ppx_enumerate-windows" {>= "v0.16" & < "v0.17"}
+  "ppx_globalize" {>= "v0.16" & < "v0.17"}
+  "ppx_globalize-windows" {>= "v0.16" & < "v0.17"}
+  "ppx_hash"      {>= "v0.16" & < "v0.17"}
+  "ppx_hash-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows" {>= "v0.16" & < "v0.17"}
+  "dune"          {>= "2.0.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+synopsis: "Base set of ppx rewriters"
+description: "
+ppx_base is the set of ppx rewriters used for Base.
+
+Note that Base doesn't need ppx to build, it is only used as a
+verification tool.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_base-v0.16.0.tar.gz"
+checksum: "sha256=64835763153d3262a2fa56cf307a351ebfd10cedf504c488ab3bb93f3d9569a3"
+}

--- a/packages/ppx_bench-windows/ppx_bench-windows.v0.16.0/opam
+++ b/packages/ppx_bench-windows/ppx_bench-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bench"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bench.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_bench" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"           {>= "4.14.0"}
+  "ppx_inline_test" {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test-windows" {>= "v0.16" & < "v0.17"}
+  "dune"            {>= "2.0.0"}
+  "ppxlib"          {>= "0.28.0"}
+  "ppxlib-windows"          {>= "0.28.0"}
+]
+synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_bench-v0.16.0.tar.gz"
+checksum: "sha256=e307fc25b4cb38125685fa01888255d00aaf6c1b82f52c4f02ebd48a4471761d"
+}

--- a/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.16.0/opam
+++ b/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.16.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bin_prot"
+bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_bin_prot" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "bin_prot-windows" {>= "v0.16" & < "v0.17"}
+  "ppx_here" {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+synopsis: "Generation of bin_prot readers and writers from types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_bin_prot-v0.16.0.tar.gz"
+checksum: "sha256=94486e7d6357f12f8aa358196783822c500b3b2fe04c597ea86c1c42bc5c3b61"
+}

--- a/packages/ppx_cold-windows/ppx_cold-windows.v0.16.0/opam
+++ b/packages/ppx_cold-windows/ppx_cold-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_cold"
+bug-reports: "https://github.com/janestreet/ppx_cold/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_cold.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_cold" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Expands [@cold] into [@inline never][@specialise never][@local never]"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_cold-v0.16.0.tar.gz"
+checksum: "sha256=803bdb583b501aa246d8ae34be0c16b892d8ae96852bb593f3e355232e6aa4da"
+}

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.16.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_compare"
+bug-reports: "https://github.com/janestreet/ppx_compare/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_compare.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_compare" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Generation of comparison functions from types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_compare-v0.16.0.tar.gz"
+checksum: "sha256=7ac1dd852e62de6c4b6a879b8bd962c0167db822c39e8c972c8a6af4c48f26aa"
+}

--- a/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.16.0/opam
+++ b/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.16.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_custom_printf"
+bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_custom_printf/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_custom_printf" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "4.14.0"}
+  "base"          {>= "v0.16" & < "v0.17"}
+  "base-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows" {>= "v0.16" & < "v0.17"}
+  "dune"          {>= "2.0.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+synopsis: "Printf-style format-strings for user-defined string conversion"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_custom_printf-v0.16.0.tar.gz"
+checksum: "sha256=2161639b7b81712abf503098202e108b3cff3d652f0ee517908081308264a1a6"
+}

--- a/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.16.0/opam
+++ b/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_disable_unused_warnings"
+bug-reports: "https://github.com/janestreet/ppx_disable_unused_warnings/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_disable_unused_warnings.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_disable_unused_warnings/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_disable_unused_warnings" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_disable_unused_warnings-v0.16.0.tar.gz"
+checksum: "sha256=3fd18ff840e4f84eb34683efdd56508ba330011b8f906d0f60684f8fce4298e7"
+}

--- a/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.16.0/opam
+++ b/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_enumerate"
+bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_enumerate" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Generate a list containing all values of a finite type"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_enumerate-v0.16.0.tar.gz"
+checksum: "sha256=2832635d6d9ac4c63d48ed51d72745cd8a548e226a6110909d5a412d40ef9953"
+}

--- a/packages/ppx_expect-windows/ppx_expect-windows.v0.16.0/opam
+++ b/packages/ppx_expect-windows/ppx_expect-windows.v0.16.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_expect" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"           {>= "4.14.0"}
+  "base"            {>= "v0.16" & < "v0.17"}
+  "base-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_here"        {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows"        {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test" {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test-windows" {>= "v0.16" & < "v0.17"}
+  "stdio-windows"           {>= "v0.16" & < "v0.17"}
+  "dune"            {>= "2.0.0"}
+  "ppxlib"          {>= "0.28.0"}
+  "ppxlib-windows"          {>= "0.28.0"}
+  "re-windows"              {>= "1.8.0"}
+]
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_expect-v0.16.0.tar.gz"
+checksum: "sha256=e0795a0ae2d576758aaaa685440951b28fe75d072d88f5c6bf415fb1a44e423c"
+}

--- a/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.16.0/opam
+++ b/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_fields_conv"
+bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_fields_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"     {>= "4.14.0"}
+  "base"      {>= "v0.16" & < "v0.17"}
+  "base-windows"      {>= "v0.16" & < "v0.17"}
+  "fieldslib-windows" {>= "v0.16" & < "v0.17"}
+  "dune"      {>= "2.0.0"}
+  "ppxlib"    {>= "0.28.0"}
+  "ppxlib-windows"    {>= "0.28.0"}
+]
+synopsis: "Generation of accessor and iteration functions for ocaml records"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_fields_conv-v0.16.0.tar.gz"
+checksum: "sha256=b098fab38b5204114623a791e7034ff1316e676ba984ca70cadb4084dfc61898"
+}

--- a/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.16.0/opam
+++ b/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_fixed_literal"
+bug-reports: "https://github.com/janestreet/ppx_fixed_literal/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_fixed_literal.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fixed_literal/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_fixed_literal" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Simpler notation for fixed point literals"
+description: "
+A ppx rewriter that rewrites fixed point literal of the 
+form 1.0v to conversion functions currently in scope.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_fixed_literal-v0.16.0.tar.gz"
+checksum: "sha256=a7d1a3d4f8ac3e9db9a6e03a8fb58d07c2b9c4050d154d782c4057789e488339"
+}

--- a/packages/ppx_globalize-windows/ppx_globalize-windows.v0.16.0/opam
+++ b/packages/ppx_globalize-windows/ppx_globalize-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_globalize"
+bug-reports: "https://github.com/janestreet/ppx_globalize/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_globalize.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_globalize" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "A ppx rewriter that generates functions to copy local values to the global heap"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_globalize-v0.16.0.tar.gz"
+checksum: "sha256=9068d7b4b765112974b17dd354cadf007f044afb11d2f99cd45b2e3b99ab491b"
+}

--- a/packages/ppx_hash-windows/ppx_hash-windows.v0.16.0/opam
+++ b/packages/ppx_hash-windows/ppx_hash-windows.v0.16.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_hash"
+bug-reports: "https://github.com/janestreet/ppx_hash/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_hash.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_hash" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "4.14.0"}
+  "base"          {>= "v0.16" & < "v0.17"}
+  "base-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_compare"   {>= "v0.16" & < "v0.17"}
+  "ppx_compare-windows"   {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows" {>= "v0.16" & < "v0.17"}
+  "dune"          {>= "2.0.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+synopsis: "A ppx rewriter that generates hash functions from type expressions and definitions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_hash-v0.16.0.tar.gz"
+checksum: "sha256=9b012546b7b9278bfd536f802fb6da88a11ebb5340d8aa47e9bf49acbf13b6e5"
+}

--- a/packages/ppx_here-windows/ppx_here-windows.v0.16.0/opam
+++ b/packages/ppx_here-windows/ppx_here-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_here"
+bug-reports: "https://github.com/janestreet/ppx_here/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_here.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_here/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_here" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Expands [%here] into its location"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_here-v0.16.0.tar.gz"
+checksum: "sha256=278198b92500c306fab3411e3dede264d678f203eb3295dd8dd79b70ed9273f0"
+}

--- a/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.16.0/opam
+++ b/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.16.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_ignore_instrumentation"
+bug-reports: "https://github.com/janestreet/ppx_ignore_instrumentation/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_ignore_instrumentation.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_ignore_instrumentation/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_ignore_instrumentation" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Ignore Jane Street specific instrumentation extensions"
+description: "
+Ignore Jane Street specific instrumentation extensions from internal PPXs or compiler 
+   features not yet upstreamed.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_ignore_instrumentation-v0.16.0.tar.gz"
+checksum: "sha256=522f50ef213300812658b5ea260299c072c24130502bde7e4f74eeda4c709305"
+}

--- a/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.16.0/opam
+++ b/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_inline_test" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "time_now-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_inline_test-v0.16.0.tar.gz"
+checksum: "sha256=216462f8fe988587d1e90f4a10aeb38664facb6eaeb3df60a32e9fb1a6bfbc67"
+}

--- a/packages/ppx_jane-windows/ppx_jane-windows.v0.16.0/opam
+++ b/packages/ppx_jane-windows/ppx_jane-windows.v0.16.0/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_jane"
+bug-reports: "https://github.com/janestreet/ppx_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_jane" "-j" jobs "-x" "windows"]
+]
+depends: [
+  "ocaml-windows"                       {>= "4.14.0"}
+  "base_quickcheck"             {>= "v0.16" & < "v0.17"}
+  "base_quickcheck-windows"             {>= "v0.16" & < "v0.17"}
+  "ppx_assert"                  {>= "v0.16" & < "v0.17"}
+  "ppx_base"                    {>= "v0.16" & < "v0.17"}
+  "ppx_bench"                   {>= "v0.16" & < "v0.17"}
+  "ppx_bin_prot"                {>= "v0.16" & < "v0.17"}
+  "ppx_custom_printf"           {>= "v0.16" & < "v0.17"}
+  "ppx_disable_unused_warnings" {>= "v0.16" & < "v0.17"}
+  "ppx_expect"                  {>= "v0.16" & < "v0.17"}
+  "ppx_fields_conv"             {>= "v0.16" & < "v0.17"}
+  "ppx_fixed_literal"           {>= "v0.16" & < "v0.17"}
+  "ppx_here"                    {>= "v0.16" & < "v0.17"}
+  "ppx_ignore_instrumentation"  {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test"             {>= "v0.16" & < "v0.17"}
+  "ppx_let"                     {>= "v0.16" & < "v0.17"}
+  "ppx_log"                     {>= "v0.16" & < "v0.17"}
+  "ppx_module_timer"            {>= "v0.16" & < "v0.17"}
+  "ppx_optional"                {>= "v0.16" & < "v0.17"}
+  "ppx_pipebang"                {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message"            {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_value"              {>= "v0.16" & < "v0.17"}
+  "ppx_stable"                  {>= "v0.16" & < "v0.17"}
+  "ppx_stable_witness"          {>= "v0.16" & < "v0.17"}
+  "ppx_string"                  {>= "v0.16" & < "v0.17"}
+  "ppx_tydi"                    {>= "v0.16" & < "v0.17"}
+  "ppx_typerep_conv"            {>= "v0.16" & < "v0.17"}
+  "ppx_variants_conv"           {>= "v0.16" & < "v0.17"}
+  "ppx_assert-windows"                  {>= "v0.16" & < "v0.17"}
+  "ppx_base-windows"                    {>= "v0.16" & < "v0.17"}
+  "ppx_bench-windows"                   {>= "v0.16" & < "v0.17"}
+  "ppx_bin_prot-windows"                {>= "v0.16" & < "v0.17"}
+  "ppx_custom_printf-windows"           {>= "v0.16" & < "v0.17"}
+  "ppx_disable_unused_warnings-windows" {>= "v0.16" & < "v0.17"}
+  "ppx_expect-windows"                  {>= "v0.16" & < "v0.17"}
+  "ppx_fields_conv-windows"             {>= "v0.16" & < "v0.17"}
+  "ppx_fixed_literal-windows"           {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows"                    {>= "v0.16" & < "v0.17"}
+  "ppx_ignore_instrumentation-windows"  {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test-windows"             {>= "v0.16" & < "v0.17"}
+  "ppx_let-windows"                     {>= "v0.16" & < "v0.17"}
+  "ppx_log-windows"                     {>= "v0.16" & < "v0.17"}
+  "ppx_module_timer-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_optional-windows"                {>= "v0.16" & < "v0.17"}
+  "ppx_pipebang-windows"                {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_value-windows"              {>= "v0.16" & < "v0.17"}
+  "ppx_stable-windows"                  {>= "v0.16" & < "v0.17"}
+  "ppx_stable_witness-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_string-windows"                  {>= "v0.16" & < "v0.17"}
+  "ppx_tydi-windows"                    {>= "v0.16" & < "v0.17"}
+  "ppx_typerep_conv-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_variants_conv-windows"           {>= "v0.16" & < "v0.17"}
+  "dune"                        {>= "2.0.0"}
+  "ppxlib"                      {>= "0.28.0"}
+  "ppxlib-windows"                      {>= "0.28.0"}
+]
+synopsis: "Standard Jane Street ppx rewriters"
+description: "
+This package installs a ppx-jane executable, which is a ppx driver
+including all standard Jane Street ppx rewriters.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_jane-v0.16.0.tar.gz"
+checksum: "sha256=9d53b01dd2e38bbe82b6927f43fa27e347418045409fd2cd3e2a203a9951c133"
+}

--- a/packages/ppx_let-windows/ppx_let-windows.v0.16.0/opam
+++ b/packages/ppx_let-windows/ppx_let-windows.v0.16.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_let"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_let" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_here" {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+synopsis: "Monadic let-bindings"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_let-v0.16.0.tar.gz"
+checksum: "sha256=2f4afb3100f4f0ae87be781b0ca6710f0a360ee8edd7eeaeb7574eca4d8be65c"
+}

--- a/packages/ppx_log-windows/ppx_log-windows.v0.16.0/opam
+++ b/packages/ppx_log-windows/ppx_log-windows.v0.16.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_log"
+bug-reports: "https://github.com/janestreet/ppx_log/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_log.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_log/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_log" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"            {>= "4.14.0"}
+  "base"             {>= "v0.16" & < "v0.17"}
+  "base-windows"             {>= "v0.16" & < "v0.17"}
+  "ppx_here"         {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows"         {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv"    {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows"    {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message-windows" {>= "v0.16" & < "v0.17"}
+  "sexplib-windows"          {>= "v0.16" & < "v0.17"}
+  "dune"             {>= "2.0.0"}
+  "ppxlib"           {>= "0.28.0"}
+  "ppxlib-windows"           {>= "0.28.0"}
+]
+synopsis: "Ppx_sexp_message-like extension nodes for lazily rendering log messages"
+description: "
+Part of the Jane Street's PPX rewriters collection. 
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_log-v0.16.0.tar.gz"
+checksum: "sha256=94d92ab27d5f1e4e50d269d23e33e6819a4a1a613fe0312f59201e3c1d74faf8"
+}

--- a/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.16.0/opam
+++ b/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.16.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_module_timer"
+bug-reports: "https://github.com/janestreet/ppx_module_timer/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_module_timer.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_module_timer/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_module_timer" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_base" {>= "v0.16" & < "v0.17"}
+  "ppx_base-windows" {>= "v0.16" & < "v0.17"}
+  "stdio-windows"    {>= "v0.16" & < "v0.17"}
+  "time_now-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+synopsis: "Ppx rewriter that records top-level module startup times"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_module_timer-v0.16.0.tar.gz"
+checksum: "sha256=2aee6ebec3dc3378a88a245a2c4f7c6314e96c377a02f390622c125bcef41f74"
+}

--- a/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.16.0/opam
+++ b/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_optcomp"
+bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_optcomp" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "stdio-windows"  {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Optional compilation for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_optcomp-v0.16.0.tar.gz"
+checksum: "sha256=99b209084a5375dafce4c6b128979661ab2ab6bf898a6872d596e65ded590ba2"
+}

--- a/packages/ppx_optional-windows/ppx_optional-windows.v0.16.0/opam
+++ b/packages/ppx_optional-windows/ppx_optional-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_optional"
+bug-reports: "https://github.com/janestreet/ppx_optional/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_optional.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optional/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_optional" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Pattern matching on flat options"
+description: "
+A ppx rewriter that rewrites simple match statements with an if then
+else expression.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_optional-v0.16.0.tar.gz"
+checksum: "sha256=70f94f6794dc4ba39db69253988af429e45f608dc12d71b792a8551219bcbfab"
+}

--- a/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.16.0/opam
+++ b/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.16.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_pipebang"
+bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pipebang/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_pipebang" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "dune"   {build & >= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "A ppx rewriter that inlines reverse application operators `|>` and `|!`"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_pipebang-v0.16.0.tar.gz"
+checksum: "sha256=b9e447e49cdbc55fb0f66401ed0d7b6522fbec6518a43f7a4905af67e41efa66"
+}

--- a/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.16.0/opam
+++ b/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "sexplib0-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_sexp_conv-v0.16.0.tar.gz"
+checksum: "sha256=41bcb7a3b33bdf50428408bfaf1dbcede528a488ac8c436ce710681bcd91200d"
+}

--- a/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.16.0/opam
+++ b/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.16.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_message"
+bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_message/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_message" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "4.14.0"}
+  "base"          {>= "v0.16" & < "v0.17"}
+  "base-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_here"      {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows" {>= "v0.16" & < "v0.17"}
+  "dune"          {>= "2.0.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+synopsis: "A ppx rewriter for easy construction of s-expressions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_sexp_message-v0.16.0.tar.gz"
+checksum: "sha256=1829931dc8670232b4687b74187777061b0df5a667478e6b9dad324e30a47d38"
+}

--- a/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.16.0/opam
+++ b/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.16.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_value"
+bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_value/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_value" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "4.14.0"}
+  "base"          {>= "v0.16" & < "v0.17"}
+  "base-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_here"      {>= "v0.16" & < "v0.17"}
+  "ppx_here-windows"      {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv-windows" {>= "v0.16" & < "v0.17"}
+  "dune"          {>= "2.0.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+synopsis: "A ppx rewriter that simplifies building s-expressions from ocaml values"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_sexp_value-v0.16.0.tar.gz"
+checksum: "sha256=74d4015a4cf2582bb7d3bcaefa91d0a89c6f3cfb423d2983ec205c007631d369"
+}

--- a/packages/ppx_stable-windows/ppx_stable-windows.v0.16.0/opam
+++ b/packages/ppx_stable-windows/ppx_stable-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_stable"
+bug-reports: "https://github.com/janestreet/ppx_stable/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_stable.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_stable" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Stable types conversions generator"
+description: "
+A ppx extension for easier implementation of conversion functions between almost
+identical types.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_stable-v0.16.0.tar.gz"
+checksum: "sha256=91b8e7540662c94922d8f7cb7afa7ea73e8890341e65290785c2aca0c2173094"
+}

--- a/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.16.0/opam
+++ b/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_stable_witness"
+bug-reports: "https://github.com/janestreet/ppx_stable_witness/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_stable_witness.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable_witness/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_stable_witness" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Ppx extension for deriving a witness that a type is intended to be stable.  In this\n   context, stable means that the serialization format will never change.  This allows\n   programs running at different versions of the code to safely communicate."
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_stable_witness-v0.16.0.tar.gz"
+checksum: "sha256=4f9857612d9d65c3844bd8940b946a19472e2d5b9df29e91c829d6d0aa78c5ef"
+}

--- a/packages/ppx_string-windows/ppx_string-windows.v0.16.0/opam
+++ b/packages/ppx_string-windows/ppx_string-windows.v0.16.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_string"
+bug-reports: "https://github.com/janestreet/ppx_string/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_string.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_string" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "base"     {>= "v0.16" & < "v0.17"}
+  "base-windows"     {>= "v0.16" & < "v0.17"}
+  "ppx_base" {>= "v0.16" & < "v0.17"}
+  "ppx_base-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+synopsis: "Ppx extension for string interpolation"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_string-v0.16.0.tar.gz"
+checksum: "sha256=1f5b999446a8eeb666feb493eb6e593a66819afe610d7f95ef424b151d148336"
+}

--- a/packages/ppx_tydi-windows/ppx_tydi-windows.v0.16.0/opam
+++ b/packages/ppx_tydi-windows/ppx_tydi-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_tydi"
+bug-reports: "https://github.com/janestreet/ppx_tydi/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_tydi.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_tydi" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "4.14.0"}
+  "base"   {>= "v0.16" & < "v0.17"}
+  "base-windows"   {>= "v0.16" & < "v0.17"}
+  "dune"   {>= "2.0.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+synopsis: "Let expressions, inferring pattern type from expression."
+description: "
+Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_tydi-v0.16.0.tar.gz"
+checksum: "sha256=a363153a1f58b35b789321dca9b5b03da46bc1c9152a38d307ffb338b3e25ac6"
+}

--- a/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.16.0/opam
+++ b/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_typerep_conv"
+bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_typerep_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"   {>= "4.14.0"}
+  "base"    {>= "v0.16" & < "v0.17"}
+  "base-windows"    {>= "v0.16" & < "v0.17"}
+  "typerep-windows" {>= "v0.16" & < "v0.17"}
+  "dune"    {>= "2.0.0"}
+  "ppxlib"  {>= "0.28.0"}
+  "ppxlib-windows"  {>= "0.28.0"}
+]
+synopsis: "Generation of runtime types from type declarations"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_typerep_conv-v0.16.0.tar.gz"
+checksum: "sha256=ffd565ee7b30dbb9c57e38c0cda8b33b4153edb3adae05796e0f97a7780f0d9a"
+}

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.16.0/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.16.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_variants_conv"
+bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_variants_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "4.14.0"}
+  "base"        {>= "v0.16" & < "v0.17"}
+  "base-windows"        {>= "v0.16" & < "v0.17"}
+  "variantslib-windows" {>= "v0.16" & < "v0.17"}
+  "dune"        {>= "2.0.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+synopsis: "Generation of accessor and iteration functions for ocaml variant types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_variants_conv-v0.16.0.tar.gz"
+checksum: "sha256=20ab1035bf7661ebad1ad0745bce434616488f56a1ed3a121a8a372ec96885e4"
+}

--- a/packages/ppxlib-windows/ppxlib-windows.0.29.1/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.29.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory representation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "5.1.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "stdlib-shims"
+  "ocaml-windows" {>= "4.04.1" & < "5.1.0"}
+  "ocaml-compiler-libs-windows" {>= "v0.11.0"}
+  "ppx_derivers-windows" {>= "1.0"}
+  "sexplib0-windows" {>= "v0.12"}
+  "stdlib-shims-windows"
+]
+conflicts: [
+  "ocaml-migrate-parsetree-windows" {< "2.0.0"}
+  "base-effects-windows"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    "ppxlib"
+    "-x"
+    "windows"
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.29.1/ppxlib-0.29.1.tbz"
+  checksum: [
+    "sha256=c8ea8c8770414fdba6612e7f2d814b21a493daa974ea862a90c8e6c766e5dd79"
+    "sha512=edc468e9111cc26e31825e475fd72f55123a22fe86548e07e7d111796fecb8d60359b1b53c7eac383e5e2114cbae74dfd9c166f330e84cbeab4ddfd5797e322f"
+  ]
+}
+x-commit-hash: "36fcba0408b78963a730e0be92abdbab00b0ea26"

--- a/packages/sexplib-windows/sexplib-windows.v0.16.0/opam
+++ b/packages/sexplib-windows/sexplib-windows.v0.16.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "sexplib" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "4.14.0"}
+  "parsexp-windows"  {>= "v0.16" & < "v0.17"}
+  "sexplib0-windows" {>= "v0.16" & < "v0.17"}
+  "dune"     {>= "2.0.0"}
+  "num-windows"
+]
+synopsis: "Library for serializing OCaml values to and from S-expressions"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib-v0.16.0.tar.gz"
+checksum: "sha256=e564d5d1ca157314ba5fd64b4e89fa12c6cba8efee3becf6d09d7d9dda21ac5b"
+}

--- a/packages/sexplib0-windows/sexplib0-windows.v0.16.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.16.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/sexplib0"
+bug-reports: "https://github.com/janestreet/sexplib0/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib0.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "sexplib0" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "4.08.0"}
+  "dune"  {>= "2.0.0"}
+]
+synopsis: "Library containing the definition of S-expressions and some base converters"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib0-v0.16.0.tar.gz"
+checksum: "sha256=86dba26468194512f789f2fb709063515a9cb4e5c4461c021c239a369590701d"
+}

--- a/packages/splittable_random-windows/splittable_random-windows.v0.16.0/opam
+++ b/packages/splittable_random-windows/splittable_random-windows.v0.16.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/splittable_random"
+bug-reports: "https://github.com/janestreet/splittable_random/issues"
+dev-repo: "git+https://github.com/janestreet/splittable_random.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/splittable_random/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "splittable_random" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"            {>= "4.14.0"}
+  "base-windows"             {>= "v0.16" & < "v0.17"}
+  "ppx_assert"       {>= "v0.16" & < "v0.17"}
+  "ppx_assert-windows"       {>= "v0.16" & < "v0.17"}
+  "ppx_bench"        {>= "v0.16" & < "v0.17"}
+  "ppx_bench-windows"        {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test"  {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test-windows"  {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message" {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message-windows" {>= "v0.16" & < "v0.17"}
+  "dune"             {build & >= "2.0.0"}
+]
+synopsis: "PRNG that can be split into independent streams"
+description: "
+PRNG that can be split into independent streams
+
+A splittable pseudo-random number generator (SPRNG) functions like a PRNG in that it can
+be used as a stream of random values; it can also be \"split\" to produce a second,
+independent stream of random values.
+
+This library implements a splittable pseudo-random number generator that sacrifices
+cryptographic-quality randomness in favor of performance.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/splittable_random-v0.16.0.tar.gz"
+checksum: "sha256=e16f1b063f03e3c18ce39f2037bebf803e13f4e5bbe824f2481ff12d121ff6d3"
+}

--- a/packages/stdio-windows/stdio-windows.v0.16.0/opam
+++ b/packages/stdio-windows/stdio-windows.v0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/stdio"
+bug-reports: "https://github.com/janestreet/stdio/issues"
+dev-repo: "git+https://github.com/janestreet/stdio.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "stdio" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "4.14.0"}
+  "base-windows"  {>= "v0.16" & < "v0.17"}
+  "dune"  {>= "2.0.0"}
+]
+synopsis: "Standard IO library for OCaml"
+description: "
+Stdio implements simple input/output functionalities for OCaml.
+
+It re-exports the input/output functions of the OCaml standard
+libraries using a more consistent API.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/stdio-v0.16.0.tar.gz"
+checksum: "sha256=61f0b75950614ac5378c6ec0d822cce6463402d919d5810b736fc46522b3a73e"
+}

--- a/packages/time_now-windows/time_now-windows.v0.16.0/opam
+++ b/packages/time_now-windows/time_now-windows.v0.16.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/time_now"
+bug-reports: "https://github.com/janestreet/time_now/issues"
+dev-repo: "git+https://github.com/janestreet/time_now.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/time_now/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "time_now" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"               {>= "4.14.0"}
+  "base-windows"                {>= "v0.16" & < "v0.17"}
+  "jane-street-headers-windows" {>= "v0.16" & < "v0.17"}
+  "jst-config-windows"          {>= "v0.16" & < "v0.17"}
+  "ppx_base"            {>= "v0.16" & < "v0.17"}
+  "ppx_base-windows"            {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"         {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp-windows"         {>= "v0.16" & < "v0.17"}
+  "dune"                {build & >= "2.0.0"}
+]
+synopsis: "Reports the current time"
+description: "
+Provides a single function to report the current time in nanoseconds
+since the start of the Unix epoch.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/time_now-v0.16.0.tar.gz"
+checksum: "sha256=5fa084aadee6aaedbb8976e4a2bc0c1dfe69eecdd0576ff901f21eedd46dc3a1"
+}

--- a/packages/typerep-windows/typerep-windows.v0.16.0/opam
+++ b/packages/typerep-windows/typerep-windows.v0.16.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/typerep"
+bug-reports: "https://github.com/janestreet/typerep/issues"
+dev-repo: "git+https://github.com/janestreet/typerep.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "typerep" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "4.14.0"}
+  "base-windows"  {>= "v0.16" & < "v0.17"}
+  "dune"  {>= "2.0.0"}
+]
+synopsis: "Typerep is a library for runtime types"
+description: "
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/typerep-v0.16.0.tar.gz"
+checksum: "sha256=e5157fef61e0229dacf01a5677bb93416ab59ee86046904c3d691e872ed4f72c"
+}

--- a/packages/variantslib-windows/variantslib-windows.v0.16.0/opam
+++ b/packages/variantslib-windows/variantslib-windows.v0.16.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/variantslib"
+bug-reports: "https://github.com/janestreet/variantslib/issues"
+dev-repo: "git+https://github.com/janestreet/variantslib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "variantslib" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "4.14.0"}
+  "base-windows"  {>= "v0.16" & < "v0.17"}
+  "dune"  {>= "2.0.0"}
+]
+synopsis: "Part of Jane Street's Core library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/variantslib-v0.16.0.tar.gz"
+checksum: "sha256=27ae7ad0bc123861c49c3cc0a74f01e68f91d3fb6c52c84505764e96a89d372f"
+}


### PR DESCRIPTION
Starting with 0.15, `core` is now platform independent and the `core_kernel` library just re-exports `core` with a deprecation warning: https://blog.janestreet.com/goodbye-Core_kernel/

This PR updates the entire Jane Street ecosystem to v0.16.x at once. I can split it up if necessary, each successive commit *should* build on its own.

Note: The ppx libraries were mostly done by a small script I wrote and then manually checked before committing. I took the conservative approach of assuming that if a ppx depended on another ppx, it needed both the host version and the `-windows` version - this may not be true in 100% of cases, so these packages may have a few too many dependencies individually. 