### PR TITLE
bigstring-unix-windows.0.3

### DIFF
--- a/packages/bigstring-unix/bigstring-unix-windows.0.3/opam
+++ b/packages/bigstring-unix/bigstring-unix-windows.0.3/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+synopsis: "I/O functions for bigstrings using file descriptors and memory-maps"
+tags: [ "bigstring" "bigarray" ]
+homepage: "https://github.com/c-cube/ocaml-bigstring/"
+bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
+dev-repo: "git+https://github.com/c-cube/ocaml-bigstring.git"
+build: [
+  [ "dune" "build" "-p" "bigstring-unix" "-j" jobs "-x" "windows" ]
+]
+depends: [
+  "dune" {>= "1.2"}
+  "ocaml-windows" {>= "4.03.0"}
+]
+url {
+  src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"
+  checksum: [
+    "md5=dff09605881c7f6efd4a8a1a71790889"
+    "sha512=d0c530603e9bb37a704d736137953e4f2a1b1e16517587010f2fb323a5c3e4d887f558775349231ea15a98d3c085ed9daaf0a7603f165cdd0097ff2548ce790a"
+  ]
+}


### PR DESCRIPTION
`bigstring` is deprecated in favor of `bigstringaf` but `bigstringaf` is missing the functions to write and read on unix socket.