### PR TITLE
Update unicode package optional dep config

### DIFF
--- a/packages/uucd-windows/uucd-windows.15.1.0/opam
+++ b/packages/uucd-windows/uucd-windows.15.1.0/opam
@@ -28,7 +28,7 @@ depends: [
   "topkg" {build & >= "1.0.3"}
   "xmlm-windows"
 ]
-build: ["ocaml" "pkg/pkg.ml" "build" "--toolchain" "windows" "--dev-pkg" "%{dev}%"]
+build: ["ocaml" "pkg/pkg.ml" "build" "--toolchain" "windows" "--pkg-name" "uucd" "--dev-pkg" "%{dev}%"]
 dev-repo: "git+https://erratique.ch/repos/uucd.git"
 url {
   src: "https://erratique.ch/software/uucd/releases/uucd-15.1.0.tbz"

--- a/packages/uucp-windows/uucp-windows.15.1.0/opam
+++ b/packages/uucp-windows/uucp-windows.15.1.0/opam
@@ -35,12 +35,14 @@ build: [
   "build"
   "--toolchain"
   "windows"
+  "--pkg-name"
+  "uucp"
   "--dev-pkg"
   "%{dev}%"
   "--with-uunf"
-  "%{uunf:installed}%"
+  "%{uunf-windows:installed}%"
   "--with-cmdliner"
-  "%{cmdliner:installed}%"
+  "%{cmdliner-windows:installed}%"
 ]
 post-messages:
   "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."

--- a/packages/uunf-windows/uunf-windows.15.1.0/opam
+++ b/packages/uunf-windows/uunf-windows.15.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "topkg" {build & >= "1.0.3"}
   "uucd-windows" {dev & >= "15.1.0" & < "16.0.0"}
 ]
-depopts: ["uutf-windows" "cmdliner"]
+depopts: ["uutf-windows" "cmdliner-windows"]
 conflicts: [
   "uutf-windows" {< "1.0.0"}
   "cmdliner-windows" {< "1.1.0"}
@@ -36,12 +36,14 @@ build: [
   "build"
   "--toolchain"
   "windows"
+  "--pkg-name" 
+  "uunf"
   "--dev-pkg"
   "%{dev}%"
   "--with-uutf"
-  "%{uutf:installed}%"
+  "%{uutf-windows:installed}%"
   "--with-cmdliner"
-  "%{cmdliner:installed}%"
+  "%{cmdliner-windows:installed}%"
 ]
 post-messages:
   "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."


### PR DESCRIPTION
Follow on to #301. I was getting `Stack overflow` errors when I tried actually installing in an environment with other packages, and I suspect it was because I was a bit sloppy and left off some `-windows` some places.