### PR TITLE
More unicode lib fixes

### DIFF
--- a/packages/uucd-windows/uucd-windows.15.1.0/opam
+++ b/packages/uucd-windows/uucd-windows.15.1.0/opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml-windows" {>= "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "opam-installer" {build}
   "topkg" {build & >= "1.0.3"}
   "xmlm-windows"
 ]

--- a/packages/uucd-windows/uucd-windows.15.1.0/opam
+++ b/packages/uucd-windows/uucd-windows.15.1.0/opam
@@ -29,6 +29,8 @@ depends: [
   "xmlm-windows"
 ]
 build: ["ocaml" "pkg/pkg.ml" "build" "--toolchain" "windows" "--pkg-name" "uucd" "--dev-pkg" "%{dev}%"]
+install: ["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "uucd.install"]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "uucd"]
 dev-repo: "git+https://erratique.ch/repos/uucd.git"
 url {
   src: "https://erratique.ch/software/uucd/releases/uucd-15.1.0.tbz"

--- a/packages/uucp-windows/uucp-windows.15.1.0/opam
+++ b/packages/uucp-windows/uucp-windows.15.1.0/opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml-windows" {>= "4.14.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "opam-installer" {build}
   "topkg" {build & >= "1.0.3"}
   "uucd-windows" {with-test & dev & >= "15.1.0" & < "16.0.0"}
   "uunf-windows" {with-test}

--- a/packages/uucp-windows/uucp-windows.15.1.0/opam
+++ b/packages/uucp-windows/uucp-windows.15.1.0/opam
@@ -44,6 +44,8 @@ build: [
   "--with-cmdliner"
   "%{cmdliner-windows:installed}%"
 ]
+install: ["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "uucp.install"]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "uucp"]
 post-messages:
   "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
     {failure & (arch = "ppc64" | arch = "arm64")}

--- a/packages/uunf-windows/uunf-windows.15.1.0/opam
+++ b/packages/uunf-windows/uunf-windows.15.1.0/opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml-windows" {>= "4.14.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "opam-installer" {build}
   "topkg" {build & >= "1.0.3"}
   "uucd-windows" {dev & >= "15.1.0" & < "16.0.0"}
 ]

--- a/packages/uunf-windows/uunf-windows.15.1.0/opam
+++ b/packages/uunf-windows/uunf-windows.15.1.0/opam
@@ -29,6 +29,7 @@ depopts: ["uutf-windows" "cmdliner-windows"]
 conflicts: [
   "uutf-windows" {< "1.0.0"}
   "cmdliner-windows" {< "1.1.0"}
+  "conf-flambda-windows"
 ]
 build: [
   "ocaml"

--- a/packages/uunf-windows/uunf-windows.15.1.0/opam
+++ b/packages/uunf-windows/uunf-windows.15.1.0/opam
@@ -37,7 +37,7 @@ build: [
   "build"
   "--toolchain"
   "windows"
-  "--pkg-name" 
+  "--pkg-name"
   "uunf"
   "--dev-pkg"
   "%{dev}%"
@@ -46,6 +46,8 @@ build: [
   "--with-cmdliner"
   "%{cmdliner-windows:installed}%"
 ]
+install: ["opam-installer" "--prefix=%{prefix}%/windows-sysroot" "uunf.install"]
+remove: ["ocamlfind" "-toolchain" "windows" "remove" "uunf"]
 post-messages:
   "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
     {failure & (arch = "ppc64" | arch = "arm64")}

--- a/packages/uutf-windows/uutf-windows.1.0.3/opam
+++ b/packages/uutf-windows/uutf-windows.1.0.3/opam
@@ -12,6 +12,7 @@ depends: ["ocaml" {>= "4.03.0"}
           "ocaml-windows" {>= "4.03.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
+          "opam-installer" {build}
           "topkg-windows" {build & >= "1.0.3"}
           "topkg" {build & >= "1.0.3"}]
 depopts: ["cmdliner-windows"]
@@ -36,5 +37,5 @@ can be found in the Stdlib and you are encouraged to migrate to it.
 
 Uutf has no dependency and is distributed under the ISC license.
 
-Home page: http://erratique.ch/software/uutf  
+Home page: http://erratique.ch/software/uutf
 Contact: Daniel Bünzli `<daniel.buenzl i@erratique.ch>`"""


### PR DESCRIPTION

## Mark conf-flambda-windows as a conflict for uunf
This seems to be the cause of the Stack Overflow error I was getting locally

This package seems hard to build (https://github.com/dbuenzli/uunf/issues/11, https://github.com/dbuenzli/uunf/issues/15) and has [previously had issues with flambda](https://github.com/ocaml/ocaml/issues/7501)

## Add install and remove commands

This was required to actually have `dune` be able to find these.


I now actually have a switch building with these locally, so hopefully this is the end for the time being