### PR TITLE
ocaml-windows{32,64}: allow spaces in $PATH

### DIFF
--- a/packages/ocaml-windows32/ocaml-windows32.4.14.0/files/build.sh
+++ b/packages/ocaml-windows32/ocaml-windows32.4.14.0/files/build.sh
@@ -12,7 +12,7 @@ if [ `opam var conf-flambda-windows:installed` = "true" ]; then
   OPTS="--enable-flambda"
 fi
 
-export PATH=${FLEXDLL_DIR}:$PATH
+export PATH="${FLEXDLL_DIR}:$PATH"
 
 ./configure --host=$1 --prefix="${OPAM_PREFIX}/windows-sysroot" --enable-systhreads ${OPTS}
 

--- a/packages/ocaml-windows32/ocaml-windows32.4.14.0/files/install.sh
+++ b/packages/ocaml-windows32/ocaml-windows32.4.14.0/files/install.sh
@@ -12,7 +12,7 @@ cp -rf compilerlibs/*.cmxa compilerlibs/*.a "${PREFIX}/windows-sysroot/lib/ocaml
 for bin in ocamlc ocamlopt ocamlcp ocamlmklib ocamlmktop ocamldoc ocamldep; do
   cat >"${PREFIX}/windows-sysroot/bin/${bin}" <<END
 #!/bin/sh
-export PATH=${FLEXDLL_PATH}:\$PATH
+export PATH="${FLEXDLL_PATH}:\$PATH"
 ${PREFIX}/bin/ocamlrun "${PREFIX}/windows-sysroot/bin/${bin}.exe" "\$@"
 END
   chmod +x "${PREFIX}/windows-sysroot/bin/${bin}"

--- a/packages/ocaml-windows32/ocaml-windows32.4.14.0/opam
+++ b/packages/ocaml-windows32/ocaml-windows32.4.14.0/opam
@@ -30,8 +30,8 @@ conflicts: [
 synopsis: "OCaml cross-compiler for 32-bit x86 Windows targets"
 extra-files: [
   ["windows.conf.in" "md5=69f2a64db241a28e172eb316ddd9cef1"]
-  ["build.sh" "md5=566d7b331a1a33d1f6c801f2d2ea2b35"]
-  ["install.sh" "md5=b29c14dc873ecdaea04589061d6da7dd"]
+  ["build.sh" "md5=0c02dc9cf4fa5bb98b8771d22ffd15d9"]
+  ["install.sh" "md5=0e6b4e3f042e7443f35cfe7a9980e905"]
   ["patches/ostype-fix.patch" "md5=05919aebf4e0894bf8f0bc60a6932b46"]
   ["patches/configure.patch" "md5=2947eb1d16daec3d35f769093574249f"]
 ]

--- a/packages/ocaml-windows32/ocaml-windows32.4.14.1/files/build.sh
+++ b/packages/ocaml-windows32/ocaml-windows32.4.14.1/files/build.sh
@@ -12,7 +12,7 @@ if [ `opam var conf-flambda-windows:installed` = "true" ]; then
   OPTS="--enable-flambda"
 fi
 
-export PATH=${FLEXDLL_DIR}:$PATH
+export PATH="${FLEXDLL_DIR}:$PATH"
 
 ./configure --host=$1 --prefix="${OPAM_PREFIX}/windows-sysroot" --enable-systhreads ${OPTS}
 

--- a/packages/ocaml-windows32/ocaml-windows32.4.14.1/files/install.sh
+++ b/packages/ocaml-windows32/ocaml-windows32.4.14.1/files/install.sh
@@ -12,7 +12,7 @@ cp -rf compilerlibs/*.cmxa compilerlibs/*.a "${PREFIX}/windows-sysroot/lib/ocaml
 for bin in ocaml ocamlc ocamlopt ocamlcp ocamlmklib ocamlmktop ocamldoc ocamldep; do
   cat >"${PREFIX}/windows-sysroot/bin/${bin}" <<END
 #!/bin/sh
-export PATH=${FLEXDLL_PATH}:\$PATH
+export PATH="${FLEXDLL_PATH}:\$PATH"
 ${PREFIX}/bin/ocamlrun "${PREFIX}/windows-sysroot/bin/${bin}.exe" "\$@"
 END
   chmod +x "${PREFIX}/windows-sysroot/bin/${bin}"

--- a/packages/ocaml-windows32/ocaml-windows32.4.14.1/opam
+++ b/packages/ocaml-windows32/ocaml-windows32.4.14.1/opam
@@ -30,8 +30,8 @@ conflicts: [
 synopsis: "OCaml cross-compiler for 32-bit x86 Windows targets"
 extra-files: [
   ["windows.conf.in" "md5=69f2a64db241a28e172eb316ddd9cef1"]
-  ["build.sh" "md5=566d7b331a1a33d1f6c801f2d2ea2b35"]
-  ["install.sh" "md5=1935c48b6df9c902c73b287b71ed1e76"]
+  ["build.sh" "md5=0c02dc9cf4fa5bb98b8771d22ffd15d9"]
+  ["install.sh" "md5=48972538ab93f9a8452af2ddaff38f03"]
   ["patches/ostype-fix.patch" "md5=05919aebf4e0894bf8f0bc60a6932b46"]
   ["patches/configure.patch" "md5=2947eb1d16daec3d35f769093574249f"]
 ]

--- a/packages/ocaml-windows64/ocaml-windows64.4.14.0/files/build.sh
+++ b/packages/ocaml-windows64/ocaml-windows64.4.14.0/files/build.sh
@@ -12,7 +12,7 @@ if [ `opam var conf-flambda-windows:installed` = "true" ]; then
   OPTS="--enable-flambda"
 fi
 
-export PATH=${FLEXDLL_DIR}:$PATH
+export PATH="${FLEXDLL_DIR}:$PATH"
 
 ./configure --host=$1 --prefix="${OPAM_PREFIX}/windows-sysroot" --enable-systhreads ${OPTS}
 

--- a/packages/ocaml-windows64/ocaml-windows64.4.14.0/files/install.sh
+++ b/packages/ocaml-windows64/ocaml-windows64.4.14.0/files/install.sh
@@ -12,7 +12,7 @@ cp -rf compilerlibs/*.cmxa compilerlibs/*.a "${PREFIX}/windows-sysroot/lib/ocaml
 for bin in ocamlc ocamlopt ocamlcp ocamlmklib ocamlmktop ocamldoc ocamldep; do
   cat >"${PREFIX}/windows-sysroot/bin/${bin}" <<END
 #!/bin/sh
-export PATH=${FLEXDLL_PATH}:\$PATH
+export PATH="${FLEXDLL_PATH}:\$PATH"
 ${PREFIX}/bin/ocamlrun "${PREFIX}/windows-sysroot/bin/${bin}.exe" "\$@"
 END
   chmod +x "${PREFIX}/windows-sysroot/bin/${bin}"

--- a/packages/ocaml-windows64/ocaml-windows64.4.14.0/opam
+++ b/packages/ocaml-windows64/ocaml-windows64.4.14.0/opam
@@ -29,8 +29,8 @@ conflicts: [
 synopsis: "OCaml cross-compiler for 64-bit x86 Windows targets"
 extra-files: [
   ["windows.conf.in" "md5=69f2a64db241a28e172eb316ddd9cef1"]
-  ["build.sh" "md5=566d7b331a1a33d1f6c801f2d2ea2b35"]
-  ["install.sh" "md5=b29c14dc873ecdaea04589061d6da7dd"]
+  ["build.sh" "md5=0c02dc9cf4fa5bb98b8771d22ffd15d9"]
+  ["install.sh" "md5=0e6b4e3f042e7443f35cfe7a9980e905"]
   ["patches/ostype-fix.patch" "md5=05919aebf4e0894bf8f0bc60a6932b46"]
   ["patches/configure.patch" "md5=2947eb1d16daec3d35f769093574249f"]
 ]

--- a/packages/ocaml-windows64/ocaml-windows64.4.14.1/files/build.sh
+++ b/packages/ocaml-windows64/ocaml-windows64.4.14.1/files/build.sh
@@ -12,7 +12,7 @@ if [ `opam var conf-flambda-windows:installed` = "true" ]; then
   OPTS="--enable-flambda"
 fi
 
-export PATH=${FLEXDLL_DIR}:$PATH
+export PATH="${FLEXDLL_DIR}:$PATH"
 
 ./configure --host=$1 --prefix="${OPAM_PREFIX}/windows-sysroot" --enable-systhreads ${OPTS}
 

--- a/packages/ocaml-windows64/ocaml-windows64.4.14.1/files/install.sh
+++ b/packages/ocaml-windows64/ocaml-windows64.4.14.1/files/install.sh
@@ -12,7 +12,7 @@ cp -rf compilerlibs/*.cmxa compilerlibs/*.a "${PREFIX}/windows-sysroot/lib/ocaml
 for bin in ocaml ocamlc ocamlopt ocamlcp ocamlmklib ocamlmktop ocamldoc ocamldep; do
   cat >"${PREFIX}/windows-sysroot/bin/${bin}" <<END
 #!/bin/sh
-export PATH=${FLEXDLL_PATH}:\$PATH
+export PATH="${FLEXDLL_PATH}:\$PATH"
 ${PREFIX}/bin/ocamlrun "${PREFIX}/windows-sysroot/bin/${bin}.exe" "\$@"
 END
   chmod +x "${PREFIX}/windows-sysroot/bin/${bin}"

--- a/packages/ocaml-windows64/ocaml-windows64.4.14.1/opam
+++ b/packages/ocaml-windows64/ocaml-windows64.4.14.1/opam
@@ -29,8 +29,8 @@ conflicts: [
 synopsis: "OCaml cross-compiler for 64-bit x86 Windows targets"
 extra-files: [
   ["windows.conf.in" "md5=69f2a64db241a28e172eb316ddd9cef1"]
-  ["build.sh" "md5=566d7b331a1a33d1f6c801f2d2ea2b35"]
-  ["install.sh" "md5=1935c48b6df9c902c73b287b71ed1e76"]
+  ["build.sh" "md5=0c02dc9cf4fa5bb98b8771d22ffd15d9"]
+  ["install.sh" "md5=48972538ab93f9a8452af2ddaff38f03"]
   ["patches/ostype-fix.patch" "md5=05919aebf4e0894bf8f0bc60a6932b46"]
   ["patches/configure.patch" "md5=2947eb1d16daec3d35f769093574249f"]
 ]

--- a/packages/ocaml-windows64/ocaml-windows64.5.1.1/files/build.sh
+++ b/packages/ocaml-windows64/ocaml-windows64.5.1.1/files/build.sh
@@ -12,7 +12,7 @@ if [ `opam var conf-flambda-windows:installed` = "true" ]; then
   OPTS="--enable-flambda"
 fi
 
-export PATH=${FLEXDLL_DIR}:$PATH
+export PATH="${FLEXDLL_DIR}:$PATH"
 
 ./configure --host="${HOST}" --prefix="${OPAM_PREFIX}/windows-sysroot" --without-zstd --enable-systhreads ${OPTS}
 

--- a/packages/ocaml-windows64/ocaml-windows64.5.1.1/files/install.sh
+++ b/packages/ocaml-windows64/ocaml-windows64.5.1.1/files/install.sh
@@ -13,7 +13,7 @@ cp -rf compilerlibs/*.cmxa compilerlibs/*.a "${PREFIX}/windows-sysroot/lib/ocaml
 for bin in ocaml ocamlc ocamlopt ocamlcp ocamlmklib ocamlmktop ocamldoc ocamldep; do
   cat >"${PREFIX}/windows-sysroot/bin/${bin}" <<END
 #!/bin/sh
-export PATH=${FLEXDLL_PATH}:\$PATH
+export PATH="${FLEXDLL_PATH}:\$PATH"
 ${PREFIX}/bin/ocamlrun "${PREFIX}/windows-sysroot/bin/${bin}.exe" "\$@"
 END
   chmod +x "${PREFIX}/windows-sysroot/bin/${bin}"

--- a/packages/ocaml-windows64/ocaml-windows64.5.1.1/opam
+++ b/packages/ocaml-windows64/ocaml-windows64.5.1.1/opam
@@ -29,8 +29,8 @@ conflicts: [
 synopsis: "OCaml cross-compiler for 64-bit x86 Windows targets"
 extra-files: [
   ["windows.conf.in" "md5=e3b6250be08dc3a108695b6610bcd7f8"]
-  ["build.sh" "md5=60fbd2b09fecf1e886605f38e81922ed"]
-  ["install.sh" "md5=771227318703c168f819281d3c051b29"]
+  ["build.sh" "md5=3c18095f474f74dc832262fe7f3dd587"]
+  ["install.sh" "md5=166b007726c8a1de4a172eb2ae5a4355"]
   ["patches/ostype-fix.patch" "md5=57404edca01e9a353f28d3b3c0139f55"]
   ["patches/configure.patch" "md5=11532eb26b881d38db59a00341823b99"]
 ]


### PR DESCRIPTION
This fixes the `ocaml-windows{32,64}` patches so that they work if `$PATH` contains spaces, which is common in WSL.