### PR TITLE
+cmdliner-windows.1.3.0

### DIFF
--- a/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
+++ b/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Home page: http://erratique.ch/software/cmdliner"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"},
+  "ocaml-windows"
+]
+build: [
+    ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz"
+  checksum:
+    "sha512=4c46bc334444ff772637deae2f5ba03645d7a1b7db523470a1246acfce79b971c764d964cbb02388639b3161b279700d9ade95da550446fb32aa4849c8a8f283"
+}

--- a/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
+++ b/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
@@ -26,6 +26,7 @@ bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "ocaml-windows"
+  "dune" {build}
 ]
 build: [
     ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]

--- a/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
+++ b/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
@@ -24,7 +24,7 @@ homepage: "https://erratique.ch/software/cmdliner"
 doc: "https://erratique.ch/software/cmdliner/doc"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 depends: [
-  "ocaml" {>= "4.08.0"},
+  "ocaml" {>= "4.08.0"}
   "ocaml-windows"
 ]
 build: [


### PR DESCRIPTION
Note: Cmdliner supports a couple different styles of building. Here I am using one _different_ than what the normal opam-repo uses, as dune is so simple. As far as I can tell, it works fine