### PR TITLE
Add bounds on old ppx_deriving versions

### DIFF
--- a/packages/ppx_deriving-windows/ppx_deriving-windows.4.2.1/opam
+++ b/packages/ppx_deriving-windows/ppx_deriving-windows.4.2.1/opam
@@ -31,7 +31,7 @@ install: [
 ]
 remove: [["env" "OCAMLFIND_TOOLCHAIN=windows" "ocamlfind" "remove" "ppx_deriving-windows"]]
 depends: [
-  "ocaml" {> "4.03.0"}
+  "ocaml" {> "4.03.0" & < "4.08.0"}
   "ocamlbuild" {build}
   "ocamlfind"  {build & >= "1.6.0"}
   "cppo"       {build}

--- a/packages/ppx_deriving-windows/ppx_deriving-windows.5.2.1/opam
+++ b/packages/ppx_deriving-windows/ppx_deriving-windows.5.2.1/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "-p" "ppx_deriving" "-j" jobs "-x" "windows"]
 ]
 depends: [
-  "ocaml-windows" {>= "4.05.0"}
+  "ocaml-windows" {>= "4.05.0" & < "5.3"}
   "ocamlfind-windows"
   "dune" {>= "1.6.3"}
   "cppo" {build & >= "1.1.0"}


### PR DESCRIPTION
This is the part of #343 that is failing CI. These are just taken from upstream