### PR TITLE
+core-windows.0.17.1 and dependencies

### DIFF
--- a/packages/base-windows/base-windows.v0.17.1/opam
+++ b/packages/base-windows/base-windows.v0.17.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "base" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "ocaml_intrinsics_kernel-windows" {>= "v0.17" & < "v0.18"}
+  "sexplib0-windows"                {>= "v0.17" & < "v0.18"}
+  "dune"                    {>= "3.11.0"}
+  "dune-configurator"
+  "dune-configurator-windows"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=9ad01b82a1013ca72b9b7628c9a5d954"
+    "sha512=ed5eb5e83d8085fc06f111862d609b393e394bbdcc6e25bab50030a250ffa2e540dbee02169b6f28ec220f10f61d189cd7b5646eece910c63620f5174fb5a655"
+  ]
+}

--- a/packages/base_bigstring-windows/base_bigstring-windows.v0.17.0/files/patches/memmem-shim.patch
+++ b/packages/base_bigstring-windows/base_bigstring-windows.v0.17.0/files/patches/memmem-shim.patch
@@ -1,0 +1,31 @@
+diff --git a/orig.c b/new.c
+index 20c11bf..e355198 100644
+--- a/src/base_bigstring_stubs.c
++++ b/src/base_bigstring_stubs.c
+@@ -43,6 +43,26 @@ static inline uint16_t bswap_16 (uint16_t x)
+ #endif
+ #define bswap_32 __builtin_bswap32
+ #define bswap_64 __builtin_bswap64
++
++// https://stackoverflow.com/questions/52988769/writing-own-memmem-for-windows
++void *memmem(const void *haystack, size_t haystack_len,
++    const void * const needle, const size_t needle_len)
++{
++    if (haystack == NULL) return NULL;
++    if (haystack_len == 0) return NULL;
++    if (needle == NULL) return NULL;
++    if (needle_len == 0) return NULL;
++
++    for (const char *h = haystack;
++            haystack_len >= needle_len;
++            ++h, --haystack_len) {
++        if (!memcmp(h, needle, needle_len)) {
++            return h;
++        }
++    }
++    return NULL;
++}
++
+ #elif _MSC_VER
+ #define bswap_16 _byteswap_ushort
+ #define bswap_32 _byteswap_ulong

--- a/packages/base_bigstring-windows/base_bigstring-windows.v0.17.0/opam
+++ b/packages/base_bigstring-windows/base_bigstring-windows.v0.17.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base_bigstring"
+bug-reports: "https://github.com/janestreet/base_bigstring/issues"
+dev-repo: "git+https://github.com/janestreet/base_bigstring.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_bigstring/index.html"
+license: "MIT"
+patches: [
+  "patches/memmem-shim.patch"
+]
+build: [
+  ["dune" "build" "-p" "base_bigstring" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "int_repr-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_jane" {>= "v0.17" & < "v0.18"}
+  "ppx_jane-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "String type based on [Bigarray], for use in I/O and C-bindings"
+description: "
+String type based on [Bigarray], for use in I/O and C-bindings.
+"
+url {
+src: "https://github.com/janestreet/base_bigstring/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=0c77edb9db4f29797cd5c22dd07fdbe4ff668715be870b86dcc1d849730b8562"
+}
+extra-files: [
+  "patches/memmem-shim.patch" "md5=f75d95f1b88dabf4ff7c24622e6dd113"
+]

--- a/packages/base_quickcheck-windows/base_quickcheck-windows.v0.17.0/opam
+++ b/packages/base_quickcheck-windows/base_quickcheck-windows.v0.17.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base_quickcheck"
+bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
+dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "base_quickcheck" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"             {>= "5.1.0"}
+  "base-windows"              {>= "v0.17" & < "v0.18"}
+  "ppx_base"          {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv"   {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv-windows"   {>= "v0.17" & < "v0.18"}
+  "ppx_let"           {>= "v0.17" & < "v0.18"}
+  "ppx_let-windows"           {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"  {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message-windows"  {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value"    {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value-windows"    {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane"       {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows"       {>= "v0.17" & < "v0.18"}
+  "splittable_random-windows" {>= "v0.17" & < "v0.18"}
+  "dune"              {>= "3.11.0"}
+  "ppxlib"            {>= "0.28.0"}
+  "ppxlib-windows"            {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Randomized testing framework, designed for compatibility with Base"
+description: "
+Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,
+with support for built-in types as well as types provided by Base.
+"
+url {
+src: "https://github.com/janestreet/base_quickcheck/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=bb1e7362d52e00cb4c460ee64a05133aee12f120a81a682ceb5fb09d11d8acea"
+}

--- a/packages/bin_prot-windows/bin_prot-windows.v0.17.0/opam
+++ b/packages/bin_prot-windows/bin_prot-windows.v0.17.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/bin_prot"
+bug-reports: "https://github.com/janestreet/bin_prot/issues"
+dev-repo: "git+https://github.com/janestreet/bin_prot.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "bin_prot" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"              {>= "5.1.0"}
+  "base-windows"               {>= "v0.17" & < "v0.18"}
+  "ppx_compare"        {>= "v0.17" & < "v0.18"}
+  "ppx_compare-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_custom_printf"  {>= "v0.17" & < "v0.18"}
+  "ppx_custom_printf-windows"  {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv"    {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv-windows"    {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp"        {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_stable_witness" {>= "v0.17" & < "v0.18"}
+  "ppx_stable_witness-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_variants_conv"  {>= "v0.17" & < "v0.18"}
+  "ppx_variants_conv-windows"  {>= "v0.17" & < "v0.18"}
+  "dune"               {>= "3.11.0"}
+]
+depopts: [
+  "mirage-xen-ocaml"
+]
+available: arch != "arm32" & arch != "x86_32" & os != "freebsd" & os-family != "opensuse" & os-family != "suse"
+synopsis: "A binary protocol generator"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://github.com/janestreet/bin_prot/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=0e6c61aff150d19a0f89cb3e354ab36189e4bc23e28ab8bce03b6c6b6004f237"
+}

--- a/packages/capitalization-windows/capitalization-windows.v0.17.0/opam
+++ b/packages/capitalization-windows/capitalization-windows.v0.17.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/capitalization"
+bug-reports: "https://github.com/janestreet/capitalization/issues"
+dev-repo: "git+https://github.com/janestreet/capitalization.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/capitalization/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "capitalization" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_base" {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Defines case conventions and functions to rename identifiers according to them"
+description: "
+"
+url {
+src: "https://github.com/janestreet/capitalization/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=f71d45ec929c9fc9b08e07723c15b6663b0143c4465b5d93038f653258cd5c6f"
+}

--- a/packages/core-windows/core-windows.v0.17.1/opam
+++ b/packages/core-windows/core-windows.v0.17.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "git+https://github.com/janestreet/core.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "core" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"               {>= "5.1.0"}
+  "base-windows"                {>= "v0.17" & < "v0.18"}
+  "base_bigstring-windows"      {>= "v0.17" & < "v0.18"}
+  "base_quickcheck-windows"     {>= "v0.17" & < "v0.18"}
+  "bin_prot-windows"            {>= "v0.17" & < "v0.18"}
+  "fieldslib-windows"           {>= "v0.17" & < "v0.18"}
+  "jane-street-headers-windows" {>= "v0.17" & < "v0.18"}
+  "jst-config-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_assert"          {>= "v0.17" & < "v0.18"}
+  "ppx_assert-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_base"            {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_diff"            {>= "v0.17" & < "v0.18"}
+  "ppx_diff-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_hash"            {>= "v0.17" & < "v0.18"}
+  "ppx_hash-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test"     {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_jane"            {>= "v0.17" & < "v0.18"}
+  "ppx_jane-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp"         {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp-windows"         {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv"       {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows"       {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"    {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message-windows"    {>= "v0.17" & < "v0.18"}
+  "sexplib-windows"             {>= "v0.17" & < "v0.18"}
+  "splittable_random-windows"   {>= "v0.17" & < "v0.18"}
+  "stdio-windows"               {>= "v0.17" & < "v0.18"}
+  "time_now-windows"            {>= "v0.17" & < "v0.18"}
+  "typerep-windows"             {>= "v0.17" & < "v0.18"}
+  "variantslib-windows"         {>= "v0.17" & < "v0.18"}
+  "dune"                {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+This is the system-independent part of Core. Unix-specific parts were moved to [core_unix].
+"
+url {
+  src: "https://github.com/janestreet/core/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=743a141234e04210e295980f7a78a6d9"
+    "sha512=61b415f4fb12c78d30649fff1aabe3a475eea926ce6edb7774031f4dc7f37ea51f5d9337ead6ec73cd93da5fd1ed0f2738c210c71ebc8fe9d7f6135a06bd176f"
+  ]
+}

--- a/packages/fieldslib-windows/fieldslib-windows.v0.17.0/opam
+++ b/packages/fieldslib-windows/fieldslib-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/fieldslib"
+bug-reports: "https://github.com/janestreet/fieldslib/issues"
+dev-repo: "git+https://github.com/janestreet/fieldslib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "fieldslib" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "base-windows"  {>= "v0.17" & < "v0.18"}
+  "dune"  {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://github.com/janestreet/fieldslib/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=3d6001f7355d2dfb0f33fb7e64f39e34bda0917277609f5ec9a0703aa17b7dfa"
+}

--- a/packages/gel-windows/gel-windows.v0.17.0/opam
+++ b/packages/gel-windows/gel-windows.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/gel"
+bug-reports: "https://github.com/janestreet/gel/issues"
+dev-repo: "git+https://github.com/janestreet/gel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/gel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "gel" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_jane" {>= "v0.17" & < "v0.18"}
+  "ppx_jane-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A library to mark non-record fields global."
+description: "
+A library to mark non-record fields global. GEL stands for Global Even if inside a Local.
+"
+url {
+src: "https://github.com/janestreet/gel/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=80e3c39fa654d770329d8e2e1bb792e8eb18ceb2dd16fb2d9037830ad73c434f"
+}

--- a/packages/int_repr-windows/int_repr-windows.v0.17.0/opam
+++ b/packages/int_repr-windows/int_repr-windows.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/int_repr"
+bug-reports: "https://github.com/janestreet/int_repr/issues"
+dev-repo: "git+https://github.com/janestreet/int_repr.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/int_repr/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "int_repr" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_jane" {>= "v0.17" & < "v0.18"}
+  "ppx_jane-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Integers of various widths"
+description: "
+Integers of various widths.
+"
+url {
+src: "https://github.com/janestreet/int_repr/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=84834341ee55934dec68f3fb6ea9328092eece8ec7f079ac3eee2a11d08c52df"
+}

--- a/packages/jane-street-headers-windows/jane-street-headers-windows.v0.17.0/opam
+++ b/packages/jane-street-headers-windows/jane-street-headers-windows.v0.17.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/jane-street-headers"
+bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
+dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jane-street-headers/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "jane-street-headers" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "dune"  {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Jane Street C header files"
+description: "
+C header files shared between the various Jane Street packages
+"
+url {
+src: "https://github.com/janestreet/jane-street-headers/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=78fa6084cd067b7a7d930d1fe1cb7eb9dcd1a90c73017e570213b47a3762eb4f"
+}

--- a/packages/jst-config-windows/jst-config-windows.v0.17.0/opam
+++ b/packages/jst-config-windows/jst-config-windows.v0.17.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/jst-config"
+bug-reports: "https://github.com/janestreet/jst-config/issues"
+dev-repo: "git+https://github.com/janestreet/jst-config.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jst-config/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "jst-config" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"             {>= "5.1.0"}
+  "base-windows"              {>= "v0.17" & < "v0.18"}
+  "ppx_assert"        {>= "v0.17" & < "v0.18"}
+  "ppx_assert-windows"        {>= "v0.17" & < "v0.18"}
+  "dune"              {>= "3.11.0"}
+  "dune-configurator-windows"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Compile-time configuration for Jane Street libraries"
+description: "
+Defines compile-time constants used in Jane Street libraries such as Base, Core, and
+Async.
+
+This package has an unstable interface; it is intended only to share configuration between
+different packages from Jane Street. Future updates may not be backward-compatible, and we
+do not recommend using this package directly.
+"
+url {
+src: "https://github.com/janestreet/jst-config/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=2cf345e33bed0ee4c325667e77dfc5bee8f12afd56318b7c9acf81ec875ecf6e"
+}

--- a/packages/ocaml-compiler-libs-windows/ocaml-compiler-libs-windows.v0.17.0/opam
+++ b/packages/ocaml-compiler-libs-windows/ocaml-compiler-libs-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ocaml-compiler-libs" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.2.0"}
+  "dune" {>= "1.5.1"}
+]
+synopsis: """OCaml compiler libraries repackaged"""
+description: """
+
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ...
+"""
+url {
+  src:
+    "https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v0.17.0.tar.gz"
+  checksum: [
+    "md5=aaf66efea8752475c25a942443579b41"
+    "sha512=c5cd418b0eb74e00c3f63235754bbdb3a3328ac743d6ae885424d8c50b4edaa7068572e689cb3456d222793283927f2984a1ff840b1bc3817f810b5314faf897"
+  ]
+}

--- a/packages/ocaml_intrinsics_kernel-windows/ocaml_intrinsics_kernel-windows.v0.17.1/opam
+++ b/packages/ocaml_intrinsics_kernel-windows/ocaml_intrinsics_kernel-windows.v0.17.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics_kernel"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics_kernel/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics_kernel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics_kernel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ocaml_intrinsics_kernel" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "dune" {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
+     when available, or compatible software implementation on other targets.
+     See also ocaml_intrinsics library.
+"
+url {
+  src:
+    "https://github.com/janestreet/ocaml_intrinsics_kernel/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=56ed7d0b0331e5bcfa4e016515c0267d"
+    "sha512=21e596d6407a620866cee7cab47ef1a9446d6a733b4994e809ea5566d5fa956682a5c6a6190ffb0ed48458abd658301944ed10c4389d91ecb8df677a5f87f2ab"
+  ]
+}

--- a/packages/parsexp-windows/parsexp-windows.v0.17.0/opam
+++ b/packages/parsexp-windows/parsexp-windows.v0.17.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/parsexp"
+bug-reports: "https://github.com/janestreet/parsexp/issues"
+dev-repo: "git+https://github.com/janestreet/parsexp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "parsexp" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "sexplib0-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "S-expression parsing library"
+description: "
+This library provides generic parsers for parsing S-expressions from
+strings or other medium.
+
+The library is focused on performances but still provide full generic
+parsers that can be used with strings, bigstrings, lexing buffers,
+character streams or any other sources effortlessly.
+
+It provides three different class of parsers:
+- the normal parsers, producing [Sexp.t] or [Sexp.t list] values
+- the parsers with positions, building compact position sequences so
+  that one can recover original positions in order to report properly
+  located errors at little cost
+- the Concrete Syntax Tree parsers, produce values of type
+  [Parsexp.Cst.t] which record the concrete layout of the s-expression
+  syntax, including comments
+
+This library is portable and doesn't provide IO functions. To read
+s-expressions from files or other external sources, you should use
+parsexp_io.
+"
+url {
+src: "https://github.com/janestreet/parsexp/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=a3d10edbc4f98d16357b644d550fd1c06f4d9aa4990ab8ee6da01276c24d55b5"
+}

--- a/packages/ppx_assert-windows/ppx_assert-windows.v0.17.0/opam
+++ b/packages/ppx_assert-windows/ppx_assert-windows.v0.17.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_assert"
+bug-reports: "https://github.com/janestreet/ppx_assert/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_assert.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_assert/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_assert" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "base-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_cold"      {>= "v0.17" & < "v0.18"}
+  "ppx_cold-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_compare"   {>= "v0.17" & < "v0.18"}
+  "ppx_compare-windows"   {>= "v0.17" & < "v0.18"}
+  "ppx_here"      {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows" {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Assert-like extension nodes that raise useful errors on failure"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_assert/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=94c47289a6393642b1cca7d2cdb8decdbf387c3cee4faf50d9b00efc871cce8b"
+}

--- a/packages/ppx_base-windows/ppx_base-windows.v0.17.0/opam
+++ b/packages/ppx_base-windows/ppx_base-windows.v0.17.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_base"
+bug-reports: "https://github.com/janestreet/ppx_base/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_base" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "ppx_cold"      {>= "v0.17" & < "v0.18"}
+  "ppx_cold-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_compare"   {>= "v0.17" & < "v0.18"}
+  "ppx_compare-windows"   {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_globalize" {>= "v0.17" & < "v0.18"}
+  "ppx_globalize-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_hash"      {>= "v0.17" & < "v0.18"}
+  "ppx_hash-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows" {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+conflicts: [
+  "base" {= "v.0.17.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Base set of ppx rewriters"
+description: "
+ppx_base is the set of ppx rewriters used for Base.
+
+Note that Base doesn't need ppx to build, it is only used as a
+verification tool.
+"
+url {
+src: "https://github.com/janestreet/ppx_base/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=80e7e6c6a704114d1d0989ee9bc01bca45278096c0caf3f2c4ef28d3c12ae61c"
+}

--- a/packages/ppx_bench-windows/ppx_bench-windows.v0.17.0/opam
+++ b/packages/ppx_bench-windows/ppx_bench-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bench"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bench.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_bench" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"           {>= "5.1.0"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test-windows" {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.28.0"}
+  "ppxlib-windows"          {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_bench/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=7e91a1b7c82fc512560ca1de14deab3754dc2df4adc924112e68bede74691ba2"
+}

--- a/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.17.0/opam
+++ b/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.17.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bin_prot"
+bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_bin_prot" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "bin_prot-windows"    {>= "v0.17" & < "v0.18"}
+  "ppx_here"    {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"    {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & != "v0.17.1"}
+  "ppxlib_jane-windows" {>= "v0.17" & != "v0.17.1"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of bin_prot readers and writers from types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_bin_prot/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=64b242cdad8b0f9ce9c86153e8e8d3e74bef9aa507d5e481c920d9154d3ab505"
+}

--- a/packages/ppx_cold-windows/ppx_cold-windows.v0.17.0/opam
+++ b/packages/ppx_cold-windows/ppx_cold-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_cold"
+bug-reports: "https://github.com/janestreet/ppx_cold/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_cold.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_cold" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Expands [@cold] into [@inline never][@specialise never][@local never]"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_cold/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=670ee6f4efef2020a4bedf91b72cc2cd97ea0d74b47dad2f8f6b72d722a7452d"
+}

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.17.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_compare"
+bug-reports: "https://github.com/janestreet/ppx_compare/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_compare.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_compare" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of comparison functions from types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_compare/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=f0b23eb78082ef4dc71a66939bbc63c6b0cc2cf6a4744a906b7a2c016cbe3098"
+}

--- a/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.17.0/opam
+++ b/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_custom_printf"
+bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_custom_printf/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_custom_printf" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "base-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows" {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Printf-style format-strings for user-defined string conversion"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_custom_printf/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=cd3cf73c31f6b0e18677ce92ce0e6f866b0596d5ea1fc540212c422930a730a0"
+}

--- a/packages/ppx_diff-windows/ppx_diff-windows.v0.17.0/opam
+++ b/packages/ppx_diff-windows/ppx_diff-windows.v0.17.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_diff"
+bug-reports: "https://github.com/janestreet/ppx_diff/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_diff.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_diff/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_diff" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "base-windows"          {>= "v0.17" & < "v0.18"}
+  "gel-windows"           {>= "v0.17" & < "v0.18"}
+  "ppx_compare"   {>= "v0.17" & < "v0.18"}
+  "ppx_compare-windows"   {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_jane"      {>= "v0.17" & < "v0.18"}
+  "ppx_jane-windows"      {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane"   {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A PPX rewriter that genreates the implementation of [Ldiffable.S]."
+description: "
+A PPX rewriter that generates the implementation of [Ldiffable.S]. Generates diffs and update functions for OCaml types.
+"
+url {
+src: "https://github.com/janestreet/ppx_diff/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=5e817094edf127d384110227ecfdc3e23f0f130266d48d1f326a03f6f58a2609"
+}

--- a/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.17.0/opam
+++ b/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_disable_unused_warnings"
+bug-reports: "https://github.com/janestreet/ppx_disable_unused_warnings/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_disable_unused_warnings.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_disable_unused_warnings/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_disable_unused_warnings" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_disable_unused_warnings/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=af5dfa6bb51aa90f5c322ab4920fb46583cffc9460f583439afb2ef851310fbf"
+}

--- a/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.17.0/opam
+++ b/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_enumerate"
+bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_enumerate" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generate a list containing all values of a finite type"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_enumerate/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=a27f1797b1315bdf7678fde783dff493bd348f1c5b644d7616b660bd295dad36"
+}

--- a/packages/ppx_expect-windows/ppx_expect-windows.v0.17.2/opam
+++ b/packages/ppx_expect-windows/ppx_expect-windows.v0.17.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_expect"
+bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_expect" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"           {>= "5.1.0"}
+  "base"            {>= "v0.17" & < "v0.18"}
+  "base-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_here"        {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test" {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test-windows" {>= "v0.17" & < "v0.18"}
+  "stdio-windows"           {>= "v0.17" & < "v0.18"}
+  "dune"            {>= "3.11.0"}
+  "ppxlib"          {>= "0.28.0"}
+  "ppxlib-windows"          {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+
+synopsis: "Cram like framework for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_expect/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=055c8c86665d158e0b03494a3e188f1c"
+    "sha512=c6394522da7f1e03df5d2f62766aa8534c09a12efff7908cc1215b06959e6eeaa2cb85514cd5def1582db66455ed922024387f28b84b4412aed4879ea905c38a"
+  ]
+}

--- a/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.17.0/opam
+++ b/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_fields_conv"
+bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_fields_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"     {>= "5.1.0"}
+  "base"      {>= "v0.17" & < "v0.18"}
+  "base-windows"      {>= "v0.17" & < "v0.18"}
+  "fieldslib-windows" {>= "v0.17" & < "v0.18"}
+  "dune"      {>= "3.11.0"}
+  "ppxlib"    {>= "0.28.0"}
+  "ppxlib-windows"    {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of accessor and iteration functions for ocaml records"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_fields_conv/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=f22ce415852181fbea91b344f4ce4dcddbfab584741924d21ad78db25eb8e16a"
+}

--- a/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.17.0/opam
+++ b/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_fixed_literal"
+bug-reports: "https://github.com/janestreet/ppx_fixed_literal/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_fixed_literal.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fixed_literal/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_fixed_literal" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Simpler notation for fixed point literals"
+description: "
+A ppx rewriter that rewrites fixed point literal of the
+form 1.0v to conversion functions currently in scope.
+"
+url {
+src: "https://github.com/janestreet/ppx_fixed_literal/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=8523872846b1e5ee7461eb55c912be4039b183de1cf2768045a6d51701a08400"
+}

--- a/packages/ppx_globalize-windows/ppx_globalize-windows.v0.17.0/opam
+++ b/packages/ppx_globalize-windows/ppx_globalize-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_globalize"
+bug-reports: "https://github.com/janestreet/ppx_globalize/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_globalize.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_globalize" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & != "v0.17.1"}
+  "ppxlib_jane-windows" {>= "v0.17" & != "v0.17.1"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx rewriter that generates functions to copy local values to the global heap"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_globalize/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=42a28764e39f641abfc723ec755c68f0b6467bf7f5057c6f326cef2c34e73618"
+}

--- a/packages/ppx_hash-windows/ppx_hash-windows.v0.17.0/opam
+++ b/packages/ppx_hash-windows/ppx_hash-windows.v0.17.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_hash"
+bug-reports: "https://github.com/janestreet/ppx_hash/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_hash.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_hash" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "base-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_compare"   {>= "v0.17" & < "v0.18"}
+  "ppx_compare-windows"   {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows" {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane"   {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx rewriter that generates hash functions from type expressions and definitions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_hash/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=8c8acae276a349d412eab9112cc3afa996d26ad4a01f2882121fc0adee0dd05e"
+}

--- a/packages/ppx_here-windows/ppx_here-windows.v0.17.0/opam
+++ b/packages/ppx_here-windows/ppx_here-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_here"
+bug-reports: "https://github.com/janestreet/ppx_here/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_here.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_here/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_here" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Expands [%here] into its location"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_here/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=27ac69db34a5ff0efbf6e3c52d52dda46d1e5d5db4d14fb4d8c20370b932a913"
+}

--- a/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.17.0/opam
+++ b/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_ignore_instrumentation"
+bug-reports: "https://github.com/janestreet/ppx_ignore_instrumentation/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_ignore_instrumentation.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_ignore_instrumentation/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_ignore_instrumentation" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Ignore Jane Street specific instrumentation extensions"
+description: "
+Ignore Jane Street specific instrumentation extensions from internal PPXs or compiler
+   features not yet upstreamed.
+"
+url {
+src: "https://github.com/janestreet/ppx_ignore_instrumentation/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=529aa92cc08a2ccb76fa361326fa7d4bbdfa2a7489c4f1c3a295658d3c758311"
+}

--- a/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.17.0/opam
+++ b/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_inline_test" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "time_now-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_inline_test/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=b71e4f01ab8aed418a3358688241a94b6d16d723deec7caaf5e4e917c2a76d2c"
+}

--- a/packages/ppx_jane-windows/ppx_jane-windows.v0.17.0/opam
+++ b/packages/ppx_jane-windows/ppx_jane-windows.v0.17.0/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_jane"
+bug-reports: "https://github.com/janestreet/ppx_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_jane" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"                       {>= "5.1.0"}
+  "base_quickcheck"             {>= "v0.17" & < "v0.18"}
+  "base_quickcheck-windows"             {>= "v0.17" & < "v0.18"}
+  "ppx_assert"                  {>= "v0.17" & < "v0.18"}
+  "ppx_assert-windows"                  {>= "v0.17" & < "v0.18"}
+  "ppx_base"                    {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows"                    {>= "v0.17" & < "v0.18"}
+  "ppx_bench"                   {>= "v0.17" & < "v0.18"}
+  "ppx_bench-windows"                   {>= "v0.17" & < "v0.18"}
+  "ppx_bin_prot"                {>= "v0.17" & < "v0.18"}
+  "ppx_bin_prot-windows"                {>= "v0.17" & < "v0.18"}
+  "ppx_custom_printf"           {>= "v0.17" & < "v0.18"}
+  "ppx_custom_printf-windows"           {>= "v0.17" & < "v0.18"}
+  "ppx_disable_unused_warnings" {>= "v0.17" & < "v0.18"}
+  "ppx_disable_unused_warnings-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_expect"                  {>= "v0.17" & < "v0.18"}
+  "ppx_expect-windows"                  {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv"             {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv-windows"             {>= "v0.17" & < "v0.18"}
+  "ppx_fixed_literal"           {>= "v0.17" & < "v0.18"}
+  "ppx_fixed_literal-windows"           {>= "v0.17" & < "v0.18"}
+  "ppx_here"                    {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"                    {>= "v0.17" & < "v0.18"}
+  "ppx_ignore_instrumentation"  {>= "v0.17" & < "v0.18"}
+  "ppx_ignore_instrumentation-windows"  {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test"             {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test-windows"             {>= "v0.17" & < "v0.18"}
+  "ppx_let"                     {>= "v0.17" & < "v0.18"}
+  "ppx_let-windows"                     {>= "v0.17" & < "v0.18"}
+  "ppx_log"                     {>= "v0.17" & < "v0.18"}
+  "ppx_log-windows"                     {>= "v0.17" & < "v0.18"}
+  "ppx_module_timer"            {>= "v0.17" & < "v0.18"}
+  "ppx_module_timer-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_optional"                {>= "v0.17" & < "v0.18"}
+  "ppx_optional-windows"                {>= "v0.17" & < "v0.18"}
+  "ppx_pipebang"                {>= "v0.17" & < "v0.18"}
+  "ppx_pipebang-windows"                {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"            {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value"              {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value-windows"              {>= "v0.17" & < "v0.18"}
+  "ppx_stable"                  {>= "v0.17" & < "v0.18"}
+  "ppx_stable-windows"                  {>= "v0.17" & < "v0.18"}
+  "ppx_stable_witness"          {>= "v0.17" & < "v0.18"}
+  "ppx_stable_witness-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_string"                  {>= "v0.17" & < "v0.18"}
+  "ppx_string-windows"                  {>= "v0.17" & < "v0.18"}
+  "ppx_string_conv"             {>= "v0.17" & < "v0.18"}
+  "ppx_string_conv-windows"             {>= "v0.17" & < "v0.18"}
+  "ppx_tydi"                    {>= "v0.17" & < "v0.18"}
+  "ppx_tydi-windows"                    {>= "v0.17" & < "v0.18"}
+  "ppx_typerep_conv"            {>= "v0.17" & < "v0.18"}
+  "ppx_typerep_conv-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_variants_conv"           {>= "v0.17" & < "v0.18"}
+  "ppx_variants_conv-windows"           {>= "v0.17" & < "v0.18"}
+  "dune"                        {>= "3.11.0"}
+  "ppxlib"                      {>= "0.28.0"}
+  "ppxlib-windows"                      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Standard Jane Street ppx rewriters"
+description: "
+This package installs a ppx-jane executable, which is a ppx driver
+including all standard Jane Street ppx rewriters.
+"
+url {
+src: "https://github.com/janestreet/ppx_jane/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=4dcf29dbb093f57fdda18b659739b255b66dc5566b6c4c8a35caa3ce8666fa65"
+}

--- a/packages/ppx_let-windows/ppx_let-windows.v0.17.0/opam
+++ b/packages/ppx_let-windows/ppx_let-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_let"
+bug-reports: "https://github.com/janestreet/ppx_let/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_let" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_here" {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Monadic let-bindings"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_let/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=6bf57833ce402720fad8ef7aabda111c0a8640cf4441df42210eb62da8a48d78"
+}

--- a/packages/ppx_log-windows/ppx_log-windows.v0.17.0/opam
+++ b/packages/ppx_log-windows/ppx_log-windows.v0.17.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_log"
+bug-reports: "https://github.com/janestreet/ppx_log/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_log.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_log/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_log" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"             {>= "5.1.0"}
+  "base"              {>= "v0.17" & < "v0.18"}
+  "base-windows"              {>= "v0.17" & < "v0.18"}
+  "ppx_compare"       {>= "v0.17" & < "v0.18"}
+  "ppx_compare-windows"       {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate"     {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_expect"        {>= "v0.17" & < "v0.18"}
+  "ppx_expect-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv"   {>= "v0.17" & < "v0.18"}
+  "ppx_fields_conv-windows"   {>= "v0.17" & < "v0.18"}
+  "ppx_here"          {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_let"           {>= "v0.17" & < "v0.18"}
+  "ppx_let-windows"           {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv"     {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message"  {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message-windows"  {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value"    {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_value-windows"    {>= "v0.17" & < "v0.18"}
+  "ppx_string"        {>= "v0.17" & < "v0.18"}
+  "ppx_string-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_variants_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_variants_conv-windows" {>= "v0.17" & < "v0.18"}
+  "sexplib-windows"           {>= "v0.17" & < "v0.18"}
+  "stdio-windows"             {>= "v0.17" & < "v0.18"}
+  "dune"              {>= "3.11.0"}
+  "ppxlib"            {>= "0.28.0"}
+  "ppxlib-windows"            {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Ppx_sexp_message-like extension nodes for lazily rendering log messages"
+description: "
+Part of the Jane Street's PPX rewriters collection. 
+"
+url {
+src: "https://github.com/janestreet/ppx_log/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=2208f047b699d0661e94415868e8e9e4a6e5287a8eceaf7318f572ccd622859a"
+}

--- a/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.17.0/opam
+++ b/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.17.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_module_timer"
+bug-reports: "https://github.com/janestreet/ppx_module_timer/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_module_timer.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_module_timer/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_module_timer" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_base" {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows" {>= "v0.17" & < "v0.18"}
+  "stdio-windows"    {>= "v0.17" & < "v0.18"}
+  "time_now-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Ppx rewriter that records top-level module startup times"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_module_timer/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=fcc39a8623f7c4e1bb40ce6ed5e9af596938f88f5718f01417ed39b11fc5e264"
+}

--- a/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.17.0/opam
+++ b/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_optcomp"
+bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_optcomp" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "stdio-windows"  {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Optional compilation for OCaml"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_optcomp/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=a62010eaf74035ee48ef2095da464f16fb6a087948a6c9d69dd1551c4836c64b"
+}

--- a/packages/ppx_optional-windows/ppx_optional-windows.v0.17.0/opam
+++ b/packages/ppx_optional-windows/ppx_optional-windows.v0.17.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_optional"
+bug-reports: "https://github.com/janestreet/ppx_optional/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_optional.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optional/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_optional" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Pattern matching on flat options"
+description: "
+A ppx rewriter that rewrites simple match statements with an if then
+else expression.
+"
+url {
+src: "https://github.com/janestreet/ppx_optional/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=809acb833048508f48c74422a5f74e4ef621807376eb5753b98bbd8f3df409bc"
+}

--- a/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.17.0/opam
+++ b/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.17.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_pipebang"
+bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pipebang/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_pipebang" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx rewriter that inlines reverse application operators `|>` and `|!`"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_pipebang/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=b50995e2e31fa1f93c2468780f5f082e0859782f8826cc05ad3ec2ad4f8c02ff"
+}

--- a/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.17.0/opam
+++ b/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.17.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane" {>= "v0.17" & < "v0.18"}
+  "ppxlib_jane-windows" {>= "v0.17" & < "v0.18"}
+  "sexplib0-windows"    {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_sexp_conv/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=4af4f99d774fab77bf63ba2298fc288c356a88bdac0a37e3a23b0d669410ee5a"
+}

--- a/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.17.0/opam
+++ b/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.17.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_message"
+bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_message/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_message" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "base-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_here"      {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows" {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx rewriter for easy construction of s-expressions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_sexp_message/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=2a02e4943106f4e87a3b2e17e5127859a4d01a4bdbe477f2084858a9962c47ee"
+}

--- a/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.17.0/opam
+++ b/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.17.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_value"
+bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_value/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_value" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"         {>= "5.1.0"}
+  "base"          {>= "v0.17" & < "v0.18"}
+  "base-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_here"      {>= "v0.17" & < "v0.18"}
+  "ppx_here-windows"      {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv-windows" {>= "v0.17" & < "v0.18"}
+  "dune"          {>= "3.11.0"}
+  "ppxlib"        {>= "0.28.0"}
+  "ppxlib-windows"        {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "A ppx rewriter that simplifies building s-expressions from ocaml values"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_sexp_value/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=599e72775285dc5a3042e4717d79f6ff1cb713ef5d7b2c46c5ee2443ad2d6e3c"
+}

--- a/packages/ppx_stable-windows/ppx_stable-windows.v0.17.0/opam
+++ b/packages/ppx_stable-windows/ppx_stable-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_stable"
+bug-reports: "https://github.com/janestreet/ppx_stable/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_stable.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_stable" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Stable types conversions generator"
+description: "
+A ppx extension for easier implementation of conversion functions between almost
+identical types.
+"
+url {
+src: "https://github.com/janestreet/ppx_stable/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=292175401b75bc23d9fb9a0f0d13547700b495815f698d481a519d9462683900"
+}

--- a/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.17.0/opam
+++ b/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_stable_witness"
+bug-reports: "https://github.com/janestreet/ppx_stable_witness/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_stable_witness.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable_witness/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_stable_witness" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Ppx extension for deriving a witness that a type is intended to be stable.  In this\n   context, stable means that the serialization format will never change.  This allows\n   programs running at different versions of the code to safely communicate."
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_stable_witness/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=052db5d52ccacaab30ead1a4192ad021ee00c235a73c09b7918acabcee4a0cda"
+}

--- a/packages/ppx_string-windows/ppx_string-windows.v0.17.0/opam
+++ b/packages/ppx_string-windows/ppx_string-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_string"
+bug-reports: "https://github.com/janestreet/ppx_string/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_string.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_string" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "base"     {>= "v0.17" & < "v0.18"}
+  "base-windows"     {>= "v0.17" & < "v0.18"}
+  "ppx_base" {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "ppxlib"   {>= "0.28.0"}
+  "ppxlib-windows"   {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Ppx extension for string interpolation"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_string/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=06b4e061fb5e2b2a85298c9829cc31a1af0a9b8e63fdee9048c76ec8d52d16ef"
+}

--- a/packages/ppx_string_conv-windows/ppx_string_conv-windows.v0.17.0/opam
+++ b/packages/ppx_string_conv-windows/ppx_string_conv-windows.v0.17.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_string_conv"
+bug-reports: "https://github.com/janestreet/ppx_string_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_string_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_string_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"          {>= "5.1.0"}
+  "base"           {>= "v0.17" & < "v0.18"}
+  "base-windows"           {>= "v0.17" & < "v0.18"}
+  "capitalization-windows" {>= "v0.17" & < "v0.18"}
+  "ppx_let"        {>= "v0.17" & < "v0.18"}
+  "ppx_let-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_string"     {>= "v0.17" & < "v0.18"}
+  "ppx_string-windows"     {>= "v0.17" & < "v0.18"}
+  "dune"           {>= "3.11.0"}
+  "ppxlib"         {>= "0.28.0"}
+  "ppxlib-windows"         {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Ppx extension for generating of_string & to_string"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_string_conv/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=2e43def9a3f13f46ac8465fa81d51784d080083539b88d3c6e8a649d5ae0fdb0"
+}

--- a/packages/ppx_tydi-windows/ppx_tydi-windows.v0.17.0/opam
+++ b/packages/ppx_tydi-windows/ppx_tydi-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_tydi"
+bug-reports: "https://github.com/janestreet/ppx_tydi/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_tydi.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_tydi" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"  {>= "5.1.0"}
+  "base"   {>= "v0.17" & < "v0.18"}
+  "base-windows"   {>= "v0.17" & < "v0.18"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Let expressions, inferring pattern type from expression."
+description: "
+Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope.
+"
+url {
+src: "https://github.com/janestreet/ppx_tydi/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=8d22dc50f0ec75380b893063a2294555dc325d21777bc09d2c6e201b391e4265"
+}

--- a/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.17.0/opam
+++ b/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_typerep_conv"
+bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_typerep_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"   {>= "5.1.0"}
+  "base"    {>= "v0.17" & < "v0.18"}
+  "base-windows"    {>= "v0.17" & < "v0.18"}
+  "typerep-windows" {>= "v0.17" & < "v0.18"}
+  "dune"    {>= "3.11.0"}
+  "ppxlib"  {>= "0.28.0"}
+  "ppxlib-windows"  {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of runtime types from type declarations"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_typerep_conv/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=eef7c7ff1e94343dd1bd25f8bf1f74b5f3adc097b454f0c1adb7e4962754809c"
+}

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.17.0/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.17.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_variants_conv"
+bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_variants_conv" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"       {>= "5.1.0"}
+  "base"        {>= "v0.17" & < "v0.18"}
+  "base-windows"        {>= "v0.17" & < "v0.18"}
+  "variantslib-windows" {>= "v0.17" & < "v0.18"}
+  "dune"        {>= "3.11.0"}
+  "ppxlib"      {>= "0.28.0"}
+  "ppxlib-windows"      {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Generation of accessor and iteration functions for ocaml variant types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppx_variants_conv/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=b66d1fe64d0adc2e7da5474f270467f1eddcba880f398ee9b0e7e0946c65b6c4"
+}

--- a/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.0/opam
+++ b/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppxlib_jane" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0" & < "5.3"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+src: "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=42757d7b44a5f2a766778e6b4710100c6ef9d0c074eb3e7fa4c69647336d8398"
+}

--- a/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.2/opam
+++ b/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppxlib_jane"
+bug-reports: "https://github.com/janestreet/ppxlib_jane/issues"
+dev-repo: "git+https://github.com/janestreet/ppxlib_jane.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppxlib_jane" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.3.0"}
+  "dune"   {>= "3.11.0"}
+  "ppxlib" {>= "0.28.0"}
+  "ppxlib-windows" {>= "0.28.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Utilities for working with Jane Street AST constructs"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=abe0bba90ad28917f344c2e31b72c7fd"
+    "sha512=342e034d44d14958869e643befb0e749d4de3ca0040891ab51592e2583bc5bb827bdaa5bd06966ac536151d160997aef79baa090247d1649a6b5849a359744d8"
+  ]
+}

--- a/packages/sexplib-windows/sexplib-windows.v0.17.0/opam
+++ b/packages/sexplib-windows/sexplib-windows.v0.17.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/sexplib"
+bug-reports: "https://github.com/janestreet/sexplib/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "sexplib" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"    {>= "5.1.0"}
+  "parsexp-windows"  {>= "v0.17" & < "v0.18"}
+  "sexplib0-windows" {>= "v0.17" & < "v0.18"}
+  "dune"     {>= "3.11.0"}
+  "num-windows"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Library for serializing OCaml values to and from S-expressions"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://github.com/janestreet/sexplib/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=da863b42b81235fdcf45eb32c04fb8bde22ff446a779cfb6f989730a35103160"
+}

--- a/packages/sexplib0-windows/sexplib0-windows.v0.17.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.17.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/sexplib0"
+bug-reports: "https://github.com/janestreet/sexplib0/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib0.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "sexplib0" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "4.14.0"}
+  "dune" {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Library containing the definition of S-expressions and some base converters"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+  src:
+    "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz"
+  checksum: [
+    "md5=abafe8fd1d6302e55a315f4d78960d2a"
+    "sha512=ad387e40789fe70a11473db7e85fe017b801592624414e9030730b2e92ea08f98095fb6e9236430f33c801605ebee0a2a6284e0f618a26a7da4599d4fd9d395d"
+  ]
+}

--- a/packages/splittable_random-windows/splittable_random-windows.v0.17.0/opam
+++ b/packages/splittable_random-windows/splittable_random-windows.v0.17.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/splittable_random"
+bug-reports: "https://github.com/janestreet/splittable_random/issues"
+dev-repo: "git+https://github.com/janestreet/splittable_random.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/splittable_random/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "splittable_random" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"            {>= "5.1.0"}
+  "base-windows"             {>= "v0.17" & < "v0.18"}
+  "ppx_assert"       {>= "v0.17" & < "v0.18"}
+  "ppx_assert-windows"       {>= "v0.17" & < "v0.18"}
+  "ppx_bench"        {>= "v0.17" & < "v0.18"}
+  "ppx_bench-windows"        {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test"  {>= "v0.17" & < "v0.18"}
+  "ppx_inline_test-windows"  {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_message-windows" {>= "v0.17" & < "v0.18"}
+  "dune"             {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "PRNG that can be split into independent streams"
+description: "
+PRNG that can be split into independent streams
+
+A splittable pseudo-random number generator (SPRNG) functions like a PRNG in that it can
+be used as a stream of random values; it can also be \"split\" to produce a second,
+independent stream of random values.
+
+This library implements a splittable pseudo-random number generator that sacrifices
+cryptographic-quality randomness in favor of performance.
+"
+url {
+src: "https://github.com/janestreet/splittable_random/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=4f8adcade214d1f84e1073a35f4751154e73853649df581cce68d20dc6337ad2"
+}

--- a/packages/stdio-windows/stdio-windows.v0.17.0/opam
+++ b/packages/stdio-windows/stdio-windows.v0.17.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/stdio"
+bug-reports: "https://github.com/janestreet/stdio/issues"
+dev-repo: "git+https://github.com/janestreet/stdio.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "stdio" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "base-windows"  {>= "v0.17" & < "v0.18"}
+  "dune"  {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Standard IO library for OCaml"
+description: "
+Stdio implements simple input/output functionalities for OCaml.
+
+It re-exports the input/output functions of the OCaml standard
+libraries using a more consistent API.
+"
+url {
+src: "https://github.com/janestreet/stdio/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=e7cb473d4bffcf419f307c658cf2599fab03a2b4fe655bfd0be699f8f7af176e"
+}

--- a/packages/time_now-windows/time_now-windows.v0.17.0/opam
+++ b/packages/time_now-windows/time_now-windows.v0.17.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/time_now"
+bug-reports: "https://github.com/janestreet/time_now/issues"
+dev-repo: "git+https://github.com/janestreet/time_now.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/time_now/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "time_now" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows"               {>= "5.1.0"}
+  "base-windows"                {>= "v0.17" & < "v0.18"}
+  "jane-street-headers-windows" {>= "v0.17" & < "v0.18"}
+  "jst-config-windows"          {>= "v0.17" & < "v0.18"}
+  "ppx_base"            {>= "v0.17" & < "v0.18"}
+  "ppx_base-windows"            {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp"         {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp-windows"         {>= "v0.17" & < "v0.18"}
+  "dune"                {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Reports the current time"
+description: "
+Provides a single function to report the current time in nanoseconds
+since the start of the Unix epoch.
+"
+url {
+src: "https://github.com/janestreet/time_now/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=fc85d6e46c4eb9370de9385f7bbfa6d57b4e48a9e96b20009007226b73f9530c"
+}

--- a/packages/typerep-windows/typerep-windows.v0.17.1/opam
+++ b/packages/typerep-windows/typerep-windows.v0.17.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/typerep"
+bug-reports: "https://github.com/janestreet/typerep/issues"
+dev-repo: "git+https://github.com/janestreet/typerep.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "typerep" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "base-windows"  {>= "v0.17" & < "v0.18"}
+  "dune"  {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Typerep is a library for runtime types"
+url {
+  src:
+    "https://github.com/janestreet/typerep/archive/refs/tags/v0.17.1.tar.gz"
+  checksum: [
+    "md5=1123cda36764ea0a286af25308d1c3e4"
+    "sha512=e81434ced58ab1cf3cb61d0e2c2106d81c81fe040130cfe07bb79dc3dcc834b1f51dec0faf50e06ccf8cac831e39f31a2ff4ca3dabef7bbaa61f85f13d7f44f5"
+  ]
+}

--- a/packages/variantslib-windows/variantslib-windows.v0.17.0/opam
+++ b/packages/variantslib-windows/variantslib-windows.v0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/variantslib"
+bug-reports: "https://github.com/janestreet/variantslib/issues"
+dev-repo: "git+https://github.com/janestreet/variantslib.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "variantslib" "-x" "windows" "-j" jobs]
+]
+depends: [
+  "ocaml-windows" {>= "5.1.0"}
+  "base-windows"  {>= "v0.17" & < "v0.18"}
+  "dune"  {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Part of Jane Street's Core library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+src: "https://github.com/janestreet/variantslib/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=9874b69aec9cfe6331970eb2271f7c24e5433ba696c1a9ea5a429862b62338ab"
+}


### PR DESCRIPTION
Similar to #280, this PR updates the entire Jane Street ecosystem in one go (57 packages). 

A few notes:
- This adds both ppxlib_jane-windows.v.0.17.0 and ppxlib_jane-windows.v.0.17.2 -- the former is for OCaml 5.1, the later is required for 5.3
- base_bigstring still needs the `memmem` patch, unfortunately, so I've copied it over from the previous release
- Almost all of these were generated from a hacky script I have to port over specifically Jane's libraries. Here it is, if anyone is curious:

<details><summary>auto.py</summary>
<p>

```python
import subprocess
import sys
from pathlib import Path
from distutils.version import LooseVersion


if len(sys.argv) != 2:
    print("Usage: python auto.py <package> ")
    sys.exit(1)


done = set()
todo = [sys.argv[1]]


def process(package: str):
    if package in done:
        return

    print("Processing", package)
    # assumes opam-cross-windows and opam-repository are sibling directories
    path = Path(__file__).parent.parent / "opam-repository" / "packages" / package

    versions = [x.name.split(".", maxsplit=1)[1] for x in path.iterdir() if x.is_dir()]
    if any(x.startswith("v") for x in versions):
        versions = [x for x in versions if x.startswith("v")]
    # get most recent version
    versions.sort(key=lambda x: LooseVersion(x.replace("v", "")))
    version = versions[-1]
    print("Processing", package, version)

    opam_file = path / f"{package}.{version}" / "opam"
    raw_contents = opam_file.read_text()
    contents = ""

    in_deps = False
    for line in raw_contents.splitlines():
        if "depends:" in line:
            in_deps = True
            contents += line + "\n"
            continue
        if in_deps:
            if line.strip() == "]":
                in_deps = False
                contents += line + "\n"
                continue

            # CHANGE THIS WHEN UPDATING TO NEWER VERSIONS
            if 'v0.17' in line or "= version" in line:
                dependency = line.split('"')[1]
                # recursively process the dependency
                todo.append(dependency)

            # these packages need both the native and cross-compiled versions
            if '"ppx' in line or '"base' in line and "ppx" in package:
                contents += line + "\n"
            # dune and dune-configurator _only_ need the native
            if '"dune"' in line or '"dune-configurator"' in line:
                contents += line + "\n"
                continue
            before, name, rest = line.split('"', maxsplit=2)
            contents += f'{before}"{name}-windows"{rest}\n'
        else:
            contents += line + "\n"

    contents = contents.replace("name", f'"{package}" "-x" "windows"', 1)

    destination = (
        Path(__file__).parent
        / "packages"
        / f"{package}-windows"
        / f"{package}-windows.{version}"
    )
    destination.mkdir(parents=True, exist_ok=True)
    output_file = destination / "opam"
    output_file.write_text(contents)
    done.add(package)
    # open in vscode for manual once-over
    subprocess.run(["code", output_file.as_posix()])


if __name__ == "__main__":

    while todo:
        package = todo.pop()
        process(package)

```

</p>
</details> 

This does the grunt work, and then things like the bigstring patch are manual