### PR TITLE
Use ghcr.io for images, build base on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         # ocaml compiler 4.14.1 does not have an option to build in 32 bit mode anymore.
         ocaml_version: [4.14.1, 5.3.0]
     container:
-      image: ocamlcross/windows-x64-base:${{ matrix.ocaml_version }}
+      image: ghcr.io/ocaml-cross/windows-x64-base:${{ matrix.ocaml_version }}
       options: --user root
     steps:
       - name: Checkout code
@@ -116,7 +116,7 @@ jobs:
         package: ${{ fromJson(needs.collect_revdeps.outputs.revdeps) }}
         ocaml_version: [4.14.1, 5.3.0]
     container:
-      image: ocamlcross/windows-x64-base:${{ matrix.ocaml_version }}
+      image: ghcr.io/ocaml-cross/windows-x64-base:${{ matrix.ocaml_version }}
       options: --user root
     steps:
       - name: Checkout code

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Docker image deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/ocaml-windows*/**"
+      - ".github/workflows/docker.yml"
+  workflow_dispatch:
+
+
+env:
+  BASE_IMAGE: dockcross/windows-static-x64
+
+jobs:
+  docker-deploy:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml_version: [4.14.1, 5.3.0] # synchronize with .github/workflows/ci.yml
+    name: Deploy ${{ matrix.ocaml_version }} image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Builder
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base image
+        run: |
+          docker build -t ghcr.io/ocaml-cross/windows-x64-base:${{ matrix.ocaml_version }} -f tests/Dockerfile.base . \
+            --build-arg IMAGE=${{env.BASE_IMAGE}} --build-arg SYSTEM=x64 --build-arg COMPILER=${{ matrix.ocaml_version }}
+          docker push ghcr.io/ocaml-cross/windows-x64-base:${{ matrix.ocaml_version }}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,7 +21,7 @@ else
   IMAGE="dockcross/windows-static-x86"
 fi
 
-BASE_IMAGE="ocamlcross/windows-${SYSTEM_TYPE}-base:${OCAML_VERSION}"
+BASE_IMAGE="ghcr.io/ocaml-cross/windows-${SYSTEM_TYPE}-base:${OCAML_VERSION}"
 
 if [ -n "${BUILD_BASE}" ]; then
   printf "Building ${BASE_IMAGE}.. "


### PR DESCRIPTION
As discussed in #350

I believe this removes the need for dockerhub and should prevent issues like #346