### PR TITLE
OCaml.5.3 configure: Missing variable definition

### DIFF
--- a/packages/ocaml-windows64/ocaml-windows64.5.3.0/opam
+++ b/packages/ocaml-windows64/ocaml-windows64.5.3.0/opam
@@ -40,6 +40,7 @@ build: [
     "--enable-systhreads"
     "CC=%{conf-gcc-windows64:prefix}%gcc"
     "DIRECT_LD=%{conf-gcc-windows64:prefix}%ld"
+    "LD=%{conf-gcc-windows64:prefix}%ld"
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}


### PR DESCRIPTION
If the configure script does not find ld, ocamlopt thinks it generates .lib files