### PR TITLE
CI base image: Remove the multi stage build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "packages/ocaml-windows*/**"
+      - "tests/Dockerfile.base"
       - ".github/workflows/docker.yml"
   workflow_dispatch:
 

--- a/tests/Dockerfile.base
+++ b/tests/Dockerfile.base
@@ -1,9 +1,6 @@
 ARG IMAGE
-FROM $IMAGE AS base
+FROM $IMAGE
 MAINTAINER Romain Beauxis <toots@rastageeks.org>
-
-ARG COMPILER
-ARG SYSTEM
 
 RUN (apt-get update || true) && \
       apt-get install -y --force-yes gawk aspcud binutils automake lzip && \
@@ -15,14 +12,6 @@ RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O
 
 RUN useradd -g staff --create-home opam
 
-USER opam
-
-ENV CC="" CPP="" CXX="" LD="" AS="" AR=""
-
-RUN opam init --auto --compiler=$COMPILER --disable-sandboxing
-
-USER root
-
 ADD packages/ /home/opam/opam-cross-windows/packages
 
 ADD repo /home/opam/opam-cross-windows/repo
@@ -33,7 +22,15 @@ USER opam
 
 WORKDIR /home/opam/opam-cross-windows
 
+ENV CC="" CPP="" CXX="" LD="" AS="" AR=""
+
+ARG COMPILER
+
+RUN opam init --auto --compiler=$COMPILER --disable-sandboxing
+
 RUN opam repository add windows /home/opam/opam-cross-windows
+
+ARG SYSTEM
 
 RUN if [ "$SYSTEM" = "x64" ]; then \
       export TOOLPREF64=/usr/src/mxe/usr/bin/x86_64-w64-mingw32.static- && \

--- a/tests/Dockerfile.base
+++ b/tests/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE
-FROM $IMAGE
+FROM $IMAGE AS base
 MAINTAINER Romain Beauxis <toots@rastageeks.org>
 
 RUN (apt-get update || true) && \
@@ -30,19 +30,13 @@ RUN opam init --auto --compiler=$COMPILER --disable-sandboxing
 
 RUN opam repository add windows /home/opam/opam-cross-windows
 
-ARG SYSTEM
+RUN export TOOLPREF64=/usr/src/mxe/usr/bin/x86_64-w64-mingw32.static- && \
+    eval $(opam env) && \
+    opam install -y -v ocaml-windows ocaml-windows64
 
-RUN if [ "$SYSTEM" = "x64" ]; then \
-      export TOOLPREF64=/usr/src/mxe/usr/bin/x86_64-w64-mingw32.static- && \
-      eval $(opam env) && \
-      opam install -y -v ocaml-windows ocaml-windows64; \
-    fi
-
-RUN if [ "$SYSTEM" = "x86" ]; then \
-      export TOOLPREF32=/usr/src/mxe/usr/bin/i686-w64-mingw32.static- && \
-      eval $(opam env) && \
-      opam install -y ocaml-windows ocaml-windows32; \
-    fi
-
-FROM $IMAGE
+FROM scratch
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/src/mxe/usr/bin \
+    WINEARCH=win64 \
+    CMAKE_TOOLCHAIN_FILE=/usr/src/mxe/usr/x86_64-w64-mingw32.static/share/cmake/mxe-conf.cmake \
+    CROSS_TRIPLE=x86_64-w64-mingw32.static
 COPY --from=base / /

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,22 +4,14 @@
 
 TEST_PWD=$(cd `dirname $0` && pwd)
 BASE_PWD=$(cd ${TEST_PWD}/.. && pwd)
-
-if [ -z "${SYSTEM_TYPE}" ]; then
-  SYSTEM_TYPE="x64"
-fi
+SYSTEM_TYPE="x64"
+IMAGE="docker.io/dockcross/windows-static-x64"
 
 if [ -z "${OCAML_VERSION}" ]; then
   OCAML_VERSION=4.14.1
 fi
 
- COMPILER="${OCAML_VERSION}"
-
-if [ "${SYSTEM_TYPE}" = "x64" ]; then
-  IMAGE="dockcross/windows-static-x64"
-else
-  IMAGE="dockcross/windows-static-x86"
-fi
+COMPILER="${OCAML_VERSION}"
 
 BASE_IMAGE="ghcr.io/ocaml-cross/windows-${SYSTEM_TYPE}-base:${OCAML_VERSION}"
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,7 +21,6 @@ if [ -n "${BUILD_BASE}" ]; then
   DOCKER_CMD="docker build -f ${TEST_PWD}/Dockerfile.base \
                            --build-arg COMPILER=\"${COMPILER}\" \
                            --build-arg IMAGE=\"${IMAGE}\" \
-                           --build-arg SYSTEM=\"${SYSTEM_TYPE}\" \
                            -t \"${BASE_IMAGE}\" ${BASE_PWD}"
 
   if [ -n "${VERBOSE}" ]; then


### PR DESCRIPTION
Maybe I'm doing a mistake because I miss the motivation for having a multi step build in the first place: I don't see where files are generated in one step to be erased in a following one. In any case, generated images are actually smaller (!) than when / is recursively copied in a fresh image.

And we take advantage of having the problematic environment variables unset (aka the compilation of 'opam-core' is fixed).