### PR TITLE
jane street packages v17 missing deps

### DIFF
--- a/packages/ppx_diff-windows/ppx_diff-windows.v0.17.0/opam
+++ b/packages/ppx_diff-windows/ppx_diff-windows.v0.17.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml-windows"         {>= "5.1.0"}
   "base"          {>= "v0.17" & < "v0.18"}
   "base-windows"          {>= "v0.17" & < "v0.18"}
+  "gel"           {>= "v0.17" & < "v0.18"}
   "gel-windows"           {>= "v0.17" & < "v0.18"}
   "ppx_compare"   {>= "v0.17" & < "v0.18"}
   "ppx_compare-windows"   {>= "v0.17" & < "v0.18"}

--- a/packages/ppx_string_conv-windows/ppx_string_conv-windows.v0.17.0/opam
+++ b/packages/ppx_string_conv-windows/ppx_string_conv-windows.v0.17.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml-windows"          {>= "5.1.0"}
   "base"           {>= "v0.17" & < "v0.18"}
   "base-windows"           {>= "v0.17" & < "v0.18"}
+  "capitalization" {>= "v0.17" & < "v0.18"}
   "capitalization-windows" {>= "v0.17" & < "v0.18"}
   "ppx_let"        {>= "v0.17" & < "v0.18"}
   "ppx_let-windows"        {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
Extracted from #355 as do not compile with OCaml 4.14 so that #355 CI will then try revdeps...