### PR TITLE
Re-add use of xcompile to ocamlfind-windows

### DIFF
--- a/packages/ocamlfind-windows/ocamlfind-windows.1.9.8/files/patches/use-host-ocamlfind.patch
+++ b/packages/ocamlfind-windows/ocamlfind-windows.1.9.8/files/patches/use-host-ocamlfind.patch
@@ -2,6 +2,20 @@ diff --git a/src/findlib/Makefile b/src/findlib/Makefile
 index b2317c1..e99e412 100644
 --- a/src/findlib/Makefile
 +++ b/src/findlib/Makefile
+@@ -13,10 +13,10 @@ include $(TOP)/Makefile.config
+ NAME = findlib
+ 
+ # Need compiler-libs since ocaml-4.00
+-OCAMLC = ocamlc -I +compiler-libs
+-OCAMLOPT = ocamlopt -I +compiler-libs $(OCAMLOPT_G)
++OCAMLC = ocamlfind ocamlc -I +compiler-libs
++OCAMLOPT = ocamlfind ocamlopt -I +compiler-libs $(OCAMLOPT_G)
+ OCAMLOPT_SHARED = $(OCAMLOPT)
+-OCAMLDEP = ocamldep
++OCAMLDEP = ocamlfind ocamldep
+ OCAMLLEX = ocamllex
+ #CAMLP4O =  camlp4 pa_o.cmo pa_op.cmo pr_o.cmo --
+ #CAMLP4O =  camlp4 pa_o.cmo pa_op.cmo pr_dump.cmo --
 @@ -42,10 +42,10 @@ DYNLOAD_OBJECTS  = fl_dynload.cmo
  DYNLOAD_XOBJECTS = $(DYNLOAD_OBJECTS:.cmo=.cmx)
  

--- a/packages/ocamlfind-windows/ocamlfind-windows.1.9.8/opam
+++ b/packages/ocamlfind-windows/ocamlfind-windows.1.9.8/opam
@@ -31,7 +31,7 @@ install: [
   ["env" "OCAMLFIND_TOOLCHAIN=windows" make "install"]
 ]
 extra-files: [
-  ["patches/use-host-ocamlfind.patch" "md5=63f75d4950f512de45be4852ddbeb64f"]
+  ["patches/use-host-ocamlfind.patch" "md5=1077b2d4ec3ce40b297d7bac99142dd3"]
   ["Makefile.config.in" "md5=2e3ee8bf4657b6c56932f6d26c7f87be"]
   ["gen_META.sh.in" "md5=1f083e40cef39cc08e4743f165db2f59"]
 ]


### PR DESCRIPTION
Follow on to #379, this seems to fix ppx_deriving-windows