### PR TITLE
Workaround .install issue in dune packages

### DIFF
--- a/packages/ISO8601-windows/ISO8601-windows.0.2.6/opam
+++ b/packages/ISO8601-windows/ISO8601-windows.0.2.6/opam
@@ -15,6 +15,7 @@ depends: [
 build: [
   ["dune" "build" "-p" "ISO8601" "-x" "windows" "-j" jobs]
   ["dune" "build" "@doc" "-p" "ISO8601" "-j" jobs] {with-doc}
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/ISO8601.ml.git"
 url {
@@ -24,3 +25,4 @@ url {
     "sha512=82b5cbbb636346e8d010ee569c0fad2f00bef31c3177cfee80fc02a081c5fcfb7880bf2670fe4f46423e3ae99370626c7efffc9d332cae5cbd6377c975517b3f"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ISO8601"]

--- a/packages/angstrom-windows/angstrom-windows.0.13.1/opam
+++ b/packages/angstrom-windows/angstrom-windows.0.13.1/opam
@@ -8,6 +8,7 @@ dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "angstrom" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.0"}
@@ -30,3 +31,4 @@ url {
   checksum: "md5=090267a7b843769d319073564fb3bb9a"
 }
 
+install: ["dune" "install" "-x" "windows" "-p" "angstrom"]

--- a/packages/angstrom-windows/angstrom-windows.0.15.0/opam
+++ b/packages/angstrom-windows/angstrom-windows.0.15.0/opam
@@ -7,6 +7,7 @@ bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
   ["dune" "build" "-p" "angstrom" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.0"}
@@ -28,3 +29,4 @@ url {
   src: "https://github.com/inhabitedtype/angstrom/archive/0.15.0.tar.gz"
   checksum: "md5=5104768c404ea92fd0a53a5b0f75cd50"
 }
+install: ["dune" "install" "-x" "windows" "-p" "angstrom"]

--- a/packages/angstrom-windows/angstrom-windows.0.16.1/opam
+++ b/packages/angstrom-windows/angstrom-windows.0.16.1/opam
@@ -7,6 +7,7 @@ bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
 dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
   ["dune" "build" "-p" "angstrom" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"
@@ -30,3 +31,4 @@ url {
     "sha256=143536fb4d049574c539b9990840615e078ed3dd94e1d24888293f68349a100b"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "angstrom"]

--- a/packages/ao-windows/ao-windows.0.2.4/opam
+++ b/packages/ao-windows/ao-windows.0.2.4/opam
@@ -12,17 +12,8 @@ depends: [
   "dune-configurator"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ao"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ao" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["dlfcn-win32" "libao"] {os-distribution = "mxe"}
@@ -35,3 +26,4 @@ url {
     "sha512=bea743458241e3c46c1ea9008a85058fc46c8798defb983cc6a9a6530e3e62cb8d982d6ed29a91933faa23bb422c96412c973ff004ed4d79f864941188ca234a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ao"]

--- a/packages/asetmap-windows/asetmap-windows.0.8.1/opam
+++ b/packages/asetmap-windows/asetmap-windows.0.8.1/opam
@@ -19,7 +19,10 @@ library. It essentially gets rid of `Not_found` exceptions and provide
 pretty-printers for the data types.
 
 asetmap has no dependency is distributed under the ISC license."""
-build: [[ "dune" "build" "-p" "asetmap" "-x" "windows" ]]
+build: [
+  ["dune" "build" "-p" "asetmap" "-x" "windows"]
+  ["rm" "%{name}%.install"]
+]
 url {
   src:
     "https://github.com/dune-universe/asetmap/releases/download/v0.8.1%2Bdune2/asetmap-0.8.1.dune2.tbz"
@@ -29,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "dfe4502945bf5f8befe8847c080edfc97ce54df5"
+install: ["dune" "install" "-x" "windows" "-p" "asetmap"]

--- a/packages/asn1-combinators-windows/asn1-combinators-windows.0.3.2/opam
+++ b/packages/asn1-combinators-windows/asn1-combinators-windows.0.3.2/opam
@@ -7,7 +7,10 @@ license: "ISC"
 dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
 bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
 synopsis: "Embed typed ASN.1 grammars in OCaml"
-build: [ ["dune" "build" "-p" "asn1-combinators" "-x" "windows" "-j" jobs ] ]
+build: [
+  ["dune" "build" "-p" "asn1-combinators" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows" {>="4.13.0"}
   "dune" {>= "1.2.0"}
@@ -31,3 +34,4 @@ url {
 }
 x-commit-hash: "2f80f3495ccfa88a506d83b811d74f0a2bd63114"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "asn1-combinators"]

--- a/packages/atdgen-runtime-windows/atdgen-runtime-windows.1.13.0/opam
+++ b/packages/atdgen-runtime-windows/atdgen-runtime-windows.1.13.0/opam
@@ -7,8 +7,8 @@ bug-reports: "https://github.com/mjambon/atd/issues"
 dev-repo: "git+https://github.com/mjambon/atd.git"
 build: [
   ["dune" "build" "-p" "atdgen-runtime" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "dune" {build}
   "biniou-windows"
@@ -19,3 +19,4 @@ url {
   src: "https://github.com/mjambon/atd/archive/1.13.0.tar.gz"
   checksum: "md5=da11b6157d5674e2d27cfd401eb8003a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "atdgen-runtime"]

--- a/packages/atdgen-runtime-windows/atdgen-runtime-windows.2.0.0/opam
+++ b/packages/atdgen-runtime-windows/atdgen-runtime-windows.2.0.0/opam
@@ -8,8 +8,8 @@ dev-repo: "git://github.com/mjambon/atd.git"
 
 build: [
   ["dune" "build" "-p" "atdgen-runtime" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "dune" {build & < "2"}
   "biniou-windows"
@@ -20,3 +20,4 @@ url {
   src: "https://github.com/mjambon/atd/releases/download/2.0.0/atd-2.0.0.tbz"
   checksum: "md5=14e47609397c524ea0eae7c3f14f7ccf"
 }
+install: ["dune" "install" "-x" "windows" "-p" "atdgen-runtime"]

--- a/packages/atdgen-runtime-windows/atdgen-runtime-windows.2.16.0/opam
+++ b/packages/atdgen-runtime-windows/atdgen-runtime-windows.2.16.0/opam
@@ -71,17 +71,8 @@ depends: [
 dev-repo: "git+https://github.com/ahrefs/atd.git"
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "atdgen-runtime"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "atdgen-runtime" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -92,3 +83,4 @@ url {
   ]
 }
 x-commit-hash: "695b060b60c1eb6f8d68d3b7eec68495e54d655a"
+install: ["dune" "install" "-x" "windows" "-p" "atdgen-runtime"]

--- a/packages/atdgen-runtime-windows/atdgen-runtime-windows.2.2.1/opam
+++ b/packages/atdgen-runtime-windows/atdgen-runtime-windows.2.2.1/opam
@@ -44,6 +44,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src: "https://github.com/ahrefs/atd/releases/download/2.2.1/atd-2.2.1.tbz"
@@ -52,3 +53,4 @@ url {
     "sha512=0c7f1985cc4d87ddd541bb2f7085b72f81aaef69468653319a4a52e6cd6c9318511229784a12cdb413ae500e7a5b8195759e0d8d49946a9b00f62e8dda07e8a2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "atdgen-runtime"]

--- a/packages/backoff-windows/backoff-windows.0.1.0/opam
+++ b/packages/backoff-windows/backoff-windows.0.1.0/opam
@@ -10,17 +10,8 @@ depends: [
   "ocaml-windows" {>= "4.13"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "backoff"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "backoff" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/backoff.git"
 url {
@@ -32,3 +23,4 @@ url {
   ]
 }
 x-commit-hash: "2ffac8ca51a822234b1e47af0430443b9c86cb13"
+install: ["dune" "install" "-x" "windows" "-p" "backoff"]

--- a/packages/base-windows/base-windows.v0.12.2/opam
+++ b/packages/base-windows/base-windows.v0.12.2/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"     {>= "4.04.2" & < "4.09.0"}
@@ -34,3 +35,4 @@ url {
   src: "https://github.com/janestreet/base/archive/v0.12.2.tar.gz"
   checksum: "md5=7150e848a730369a2549d01645fb6c72"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base"]

--- a/packages/base-windows/base-windows.v0.14.1/opam
+++ b/packages/base-windows/base-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.08.0"}
@@ -34,3 +35,4 @@ url {
   src: "https://github.com/janestreet/base/archive/v0.14.1.tar.gz"
   checksum: "md5=e4419eae60f57e553b154856f0cacf42"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base"]

--- a/packages/base-windows/base-windows.v0.15.0/opam
+++ b/packages/base-windows/base-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.10.0"}
@@ -36,3 +37,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/base-v0.15.0.tar.gz"
 checksum: "sha256=8657ae4324a9948457112245c49d97d2da95f157f780f5d97f0b924312a6a53d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base"]

--- a/packages/base-windows/base-windows.v0.16.3/opam
+++ b/packages/base-windows/base-windows.v0.16.3/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.14.0"}
@@ -39,3 +40,4 @@ url {
     "sha512=69380ed392faf4495459f97f70a10a6959fce71d2e6ba093472fc272141646307fd7872407de855dfa48ef0435f6587eae5aa50f4a67eac40a9e1946d0c3c070"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "base"]

--- a/packages/base-windows/base-windows.v0.17.1/opam
+++ b/packages/base-windows/base-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -40,3 +41,4 @@ url {
     "sha512=ed5eb5e83d8085fc06f111862d609b393e394bbdcc6e25bab50030a250ffa2e540dbee02169b6f28ec220f10f61d189cd7b5646eece910c63620f5174fb5a655"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "base"]

--- a/packages/base64-windows/base64-windows.2.2.0/opam
+++ b/packages/base64-windows/base64-windows.2.2.0/opam
@@ -14,8 +14,8 @@ depends: [
   "dune" {build & >= "1.0+beta10"}
 ]
 build: [
-  ["dune" "build" 
-                      "-p" "base64" "-j" jobs "-x" "windows"]
+  ["dune" "build" "-p" "base64" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 synopsis: "For OCaml"
 description: """
@@ -32,3 +32,4 @@ url {
     "https://github.com/mirage/ocaml-base64/releases/download/v2.2.0/base64-2.2.0.tbz"
   checksum: "md5=49f2bc4ae37b832c652277c0b701a02a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base64"]

--- a/packages/base64-windows/base64-windows.3.5.1/opam
+++ b/packages/base64-windows/base64-windows.3.5.1/opam
@@ -20,6 +20,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "base64" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -30,3 +31,4 @@ url {
   ]
 }
 x-commit-hash: "084346f14ed1e6706d733402dd6ff65b0dc4f718"
+install: ["dune" "install" "-x" "windows" "-p" "base64"]

--- a/packages/base_bigstring-windows/base_bigstring-windows.v0.16.0/opam
+++ b/packages/base_bigstring-windows/base_bigstring-windows.v0.16.0/opam
@@ -11,6 +11,7 @@ patches: [
 ]
 build: [
   ["dune" "build" "-p" "base_bigstring" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -31,3 +32,4 @@ checksum: "sha256=19fcbf8fa1fa557d513679413a9087e4ff1cb846cef1e8a78eaffb293fa926
 extra-files: [
   "patches/memmem-shim.patch" "md5=f75d95f1b88dabf4ff7c24622e6dd113"
 ]
+install: ["dune" "install" "-x" "windows" "-p" "base_bigstring"]

--- a/packages/base_bigstring-windows/base_bigstring-windows.v0.17.0/opam
+++ b/packages/base_bigstring-windows/base_bigstring-windows.v0.17.0/opam
@@ -11,6 +11,7 @@ patches: [
 ]
 build: [
   ["dune" "build" "-p" "base_bigstring" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -32,3 +33,4 @@ checksum: "sha256=0c77edb9db4f29797cd5c22dd07fdbe4ff668715be870b86dcc1d849730b85
 extra-files: [
   "patches/memmem-shim.patch" "md5=f75d95f1b88dabf4ff7c24622e6dd113"
 ]
+install: ["dune" "install" "-x" "windows" "-p" "base_bigstring"]

--- a/packages/base_quickcheck-windows/base_quickcheck-windows.v0.14.1/opam
+++ b/packages/base_quickcheck-windows/base_quickcheck-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base_quickcheck" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.04.2"}
@@ -36,3 +37,4 @@ url {
   src: "https://github.com/janestreet/base_quickcheck/archive/v0.14.1.tar.gz"
   checksum: "md5=d04738d4499e256b752bc40fcdb9730d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base_quickcheck"]

--- a/packages/base_quickcheck-windows/base_quickcheck-windows.v0.16.0/opam
+++ b/packages/base_quickcheck-windows/base_quickcheck-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base_quickcheck" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.14.0"}
@@ -36,3 +37,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/base_quickcheck-v0.16.0.tar.gz"
 checksum: "sha256=88f80a75d224ceed33d0f891e6bb931979ec24397871b3347b8be22ef96d2e7e"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base_quickcheck"]

--- a/packages/base_quickcheck-windows/base_quickcheck-windows.v0.17.0/opam
+++ b/packages/base_quickcheck-windows/base_quickcheck-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base_quickcheck" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "5.1.0"}
@@ -39,3 +40,4 @@ url {
 src: "https://github.com/janestreet/base_quickcheck/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=bb1e7362d52e00cb4c460ee64a05133aee12f120a81a682ceb5fb09d11d8acea"
 }
+install: ["dune" "install" "-x" "windows" "-p" "base_quickcheck"]

--- a/packages/base_quickcheck-windows/base_quickcheck-windows.v0.17.1/opam
+++ b/packages/base_quickcheck-windows/base_quickcheck-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "base_quickcheck" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "5.1.0"}
@@ -43,3 +44,4 @@ url {
     "sha512=d345b0333508f6f49fe636455139e563b0594bd2cf56534d2f42ed083906e41bb4e009996ed7db8989d8409899d25cfcdbd71021260486c310f7e0fd63df56d9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "base_quickcheck"]

--- a/packages/bigarray-compat-windows/bigarray-compat-windows.1.0.0/opam
+++ b/packages/bigarray-compat-windows/bigarray-compat-windows.1.0.0/opam
@@ -12,6 +12,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "bigarray-compat" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
 url {
@@ -21,3 +22,4 @@ url {
     "sha512=c365fee15582aca35d7b05268cde29e54774ad7df7be56762b4aad78ca1409d4326ad3b34af0f1cc2c7b872837290a9cd9ff43b47987c03bba7bba32fe8a030f"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "bigarray-compat"]

--- a/packages/bigstring-unix-windows/bigstring-unix-windows.0.3/opam
+++ b/packages/bigstring-unix-windows/bigstring-unix-windows.0.3/opam
@@ -7,7 +7,8 @@ homepage: "https://github.com/c-cube/ocaml-bigstring/"
 bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
 dev-repo: "git+https://github.com/c-cube/ocaml-bigstring.git"
 build: [
-  [ "dune" "build" "-p" "bigstring-unix" "-j" jobs "-x" "windows" ]
+  ["dune" "build" "-p" "bigstring-unix" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "1.2"}
@@ -20,3 +21,4 @@ url {
     "sha512=d0c530603e9bb37a704d736137953e4f2a1b1e16517587010f2fb323a5c3e4d887f558775349231ea15a98d3c085ed9daaf0a7603f165cdd0097ff2548ce790a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "bigstring-unix"]

--- a/packages/bigstringaf-windows/bigstringaf-windows.0.10.0/opam
+++ b/packages/bigstringaf-windows/bigstringaf-windows.0.10.0/opam
@@ -6,17 +6,8 @@ homepage: "https://github.com/inhabitedtype/bigstringaf"
 bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "bigstringaf"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "bigstringaf" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "3.0"}
@@ -40,3 +31,4 @@ url {
   src: "https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz"
   checksum: "md5=be0a44416840852777651150757a0a3b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "bigstringaf"]

--- a/packages/bigstringaf-windows/bigstringaf-windows.0.6.1/opam
+++ b/packages/bigstringaf-windows/bigstringaf-windows.0.6.1/opam
@@ -8,6 +8,7 @@ dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "bigstringaf" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "1.0"}
@@ -38,3 +39,4 @@ url {
   checksum: "md5=dccf639273b1eec0e0f142f21319268d"
 }
 
+install: ["dune" "install" "-x" "windows" "-p" "bigstringaf"]

--- a/packages/bigstringaf-windows/bigstringaf-windows.0.9.0/opam
+++ b/packages/bigstringaf-windows/bigstringaf-windows.0.9.0/opam
@@ -7,6 +7,7 @@ bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
 build: [
   ["dune" "build" "-p" "bigstringaf" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "2.6.0"}
@@ -29,3 +30,4 @@ url {
   src: "https://github.com/inhabitedtype/bigstringaf/archive/0.9.0.tar.gz"
   checksum: "md5=0d8ceddeb7db821fd4e5235a75ae9752"
 }
+install: ["dune" "install" "-x" "windows" "-p" "bigstringaf"]

--- a/packages/bigstringaf-windows/bigstringaf-windows.0.9.1/opam
+++ b/packages/bigstringaf-windows/bigstringaf-windows.0.9.1/opam
@@ -6,17 +6,8 @@ homepage: "https://github.com/inhabitedtype/bigstringaf"
 bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "bigstringaf"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "bigstringaf" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "3.0"}
@@ -39,3 +30,4 @@ url {
   src: "https://github.com/inhabitedtype/bigstringaf/archive/0.9.1.tar.gz"
   checksum: "md5=909fdc277cf03096a35b565325d5314a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "bigstringaf"]

--- a/packages/bin_prot-windows/bin_prot-windows.v0.14.0/opam
+++ b/packages/bin_prot-windows/bin_prot-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "bin_prot" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.04.2"}
@@ -40,3 +41,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/bin_prot-v0.14.0.tar.gz"
   checksum: "md5=a4fee6c7d57a05e2420a69e16c287faf"
 }
+install: ["dune" "install" "-x" "windows" "-p" "bin_prot"]

--- a/packages/bin_prot-windows/bin_prot-windows.v0.16.0/opam
+++ b/packages/bin_prot-windows/bin_prot-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "bin_prot" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"              {>= "4.14.0"}
@@ -42,3 +43,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/bin_prot-v0.16.0.tar.gz"
 checksum: "sha256=3ede8089d809186ba2bc7ade49d814c6d60e0414c2ba075807eaeb05d1d0a2f1"
 }
+install: ["dune" "install" "-x" "windows" "-p" "bin_prot"]

--- a/packages/bin_prot-windows/bin_prot-windows.v0.17.0-1/opam
+++ b/packages/bin_prot-windows/bin_prot-windows.v0.17.0-1/opam
@@ -9,6 +9,7 @@ license: "MIT"
 patches: [ "remove-outdated-mirage-xen-cross-compilation-rules.patch" ]
 build: [
   ["dune" "build" "-p" "bin_prot" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"              {>= "5.1.0"}
@@ -49,3 +50,4 @@ extra-source "remove-outdated-mirage-xen-cross-compilation-rules.patch" {
     "md5=0b9ecf65c743f358ead5ad9f586cdee0"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "bin_prot"]

--- a/packages/bin_prot-windows/bin_prot-windows.v0.17.0/opam
+++ b/packages/bin_prot-windows/bin_prot-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "bin_prot" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"              {>= "5.1.0"}
@@ -43,3 +44,4 @@ url {
 src: "https://github.com/janestreet/bin_prot/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=0e6c61aff150d19a0f89cb3e354ab36189e4bc23e28ab8bce03b6c6b6004f237"
 }
+install: ["dune" "install" "-x" "windows" "-p" "bin_prot"]

--- a/packages/biniou-windows/biniou-windows.1.2.2/opam
+++ b/packages/biniou-windows/biniou-windows.1.2.2/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "biniou" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 maintainer: ["martin@mjambon.com"]
 authors: ["Martin Jambon"]
@@ -43,3 +44,4 @@ url {
   ]
 }
 x-commit-hash: "b434dd9ad488e042cf71554af7296b7bd98c9a6a"
+install: ["dune" "install" "-x" "windows" "-p" "biniou"]

--- a/packages/ca-certs-windows/ca-certs-windows.1.0.0/opam
+++ b/packages/ca-certs-windows/ca-certs-windows.1.0.0/opam
@@ -42,6 +42,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 tags: ["org:mirage"]
 url {
@@ -54,3 +55,4 @@ url {
 }
 x-commit-hash: "2c5c0bcc2a336f77ec4bb843265334217996c559"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "ca-certs"]

--- a/packages/calendar-windows/calendar-windows.3.0.0/opam
+++ b/packages/calendar-windows/calendar-windows.3.0.0/opam
@@ -21,6 +21,7 @@ build: [
   ["dune" "build" "-p" "calendar" "-x" "windows" "-j" jobs]
   ["dune" "build" "@doc" "-p" "calendar" "-x" "windows" "-j" jobs] {with-doc}
   ["dune" "runtest" "-p" "calendar" "-x" "windows" "-j" jobs] {with-test}
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/calendar"
 url {
@@ -31,3 +32,4 @@ url {
     "sha512=cf8a5cfbfb8879da7bcacf765d5461523cbc4f0c13133dfb2f311b051ed95b5f72815af5ca2836294a793d9b57bfc4cc1abbb8b54e17954cb4ecc99e1743bdc3"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "calendar"]

--- a/packages/camlp-streams-windows/camlp-streams-windows.5.0.1/opam
+++ b/packages/camlp-streams-windows/camlp-streams-windows.5.0.1/opam
@@ -36,16 +36,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "camlp-streams"
-    "-x" "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "camlp-streams" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/camlp-streams.git"
 url {
@@ -55,3 +47,4 @@ url {
     "sha512=2efa8dd4a636217c8d49bac1e4e7e5558fc2f45cfea66514140a59fd99dd08d61fb9f1e17804997ff648b71b13820a5d4a1eb70fed9d848aa2abd6e41f853c86"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "camlp-streams"]

--- a/packages/camomile-windows/camomile-windows.1.0.2/opam
+++ b/packages/camomile-windows/camomile-windows.1.0.2/opam
@@ -18,9 +18,8 @@ depends: [
 dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
-  ["dune" "build" "-p" "camomile" "-j" jobs "-x" "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "camomile" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -31,3 +30,4 @@ url {
   ]
 }
 available: arch != "ppc64"
+install: ["dune" "install" "-x" "windows" "-p" "camomile"]

--- a/packages/camomile-windows/camomile-windows.2.0.0/opam
+++ b/packages/camomile-windows/camomile-windows.2.0.0/opam
@@ -32,9 +32,11 @@ build: [
     "camomile"
     "-j"
     jobs
-    "-x" "windows"
+    "-x"
+    "windows"
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/Camomile.git"
 url {
@@ -44,3 +46,4 @@ url {
     "sha512=b0ae3d921f65390e8ec88a04901dd097b568db9f9ae70fb328e9d3ddb2dd8922b9a8e8da9ace91ad9cb5f6a1310ae5b6ba502e287d6c828f4d60622289316ac8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "camomile"]

--- a/packages/capitalization-windows/capitalization-windows.v0.17.0/opam
+++ b/packages/capitalization-windows/capitalization-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/capitalization/index.ht
 license: "MIT"
 build: [
   ["dune" "build" "-p" "capitalization" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://github.com/janestreet/capitalization/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=f71d45ec929c9fc9b08e07723c15b6663b0143c4465b5d93038f653258cd5c6f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "capitalization"]

--- a/packages/checkseum-windows/checkseum-windows.0.2.0/opam
+++ b/packages/checkseum-windows/checkseum-windows.0.2.0/opam
@@ -16,9 +16,9 @@ This library use the linking trick to choose between the C implementation
 top of optint to get the best representation of an int32. """
 
 build: [
-  [ "dune" "build" "-p" "checkseum" "-j" jobs "-x" "windows"]
+  ["dune" "build" "-p" "checkseum" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows"
   "dune"              {>= "2.0.0"}
@@ -35,3 +35,4 @@ url {
     "sha512=63e3bdb03996551d127a7233590d7f36783e18659bbdf455ac0d6ed55798374122661e1da25b45ea0f5468d3876f617b1aac0699858f04f94137579726d5d323"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "checkseum"]

--- a/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
+++ b/packages/cmdliner-windows/cmdliner-windows.1.3.0/opam
@@ -29,7 +29,8 @@ depends: [
   "dune" {build}
 ]
 build: [
-    ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+  ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
 url {
@@ -37,3 +38,4 @@ url {
   checksum:
     "sha512=4c46bc334444ff772637deae2f5ba03645d7a1b7db523470a1246acfce79b971c764d964cbb02388639b3161b279700d9ade95da550446fb32aa4849c8a8f283"
 }
+install: ["dune" "install" "-x" "windows" "-p" "cmdliner"]

--- a/packages/cmdliner-windows/cmdliner-windows.2.0.0/opam
+++ b/packages/cmdliner-windows/cmdliner-windows.2.0.0/opam
@@ -30,7 +30,8 @@ depends: [
   "dune" {build}
 ]
 build: [
-    ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+  ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
 url {
@@ -39,3 +40,4 @@ url {
     "sha512=a7bd4eeb0cef7c08bca73b0077a65f748c19a230544133b39fc3360feb2cf0af08416a8b84031c94a2f4a007d5920a4db1368d87b9eeca561671828e2dad2885"
 }
 x-maintenance-intent: ["(latest)"]
+install: ["dune" "install" "-x" "windows" "-p" "cmdliner"]

--- a/packages/cmdliner-windows/cmdliner-windows.2.1.0/opam
+++ b/packages/cmdliner-windows/cmdliner-windows.2.1.0/opam
@@ -30,7 +30,8 @@ depends: [
   "dune" {build}
 ]
 build: [
-    ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+  ["dune" "build" "-p" "cmdliner" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
 url {
@@ -39,3 +40,4 @@ url {
     "sha512=2ca8c9a2b392e031f88aa0e76f2ab50c8e9e28d77852d04ca2d5b62326630ca41567ce0832e9a9334d9b130b48deede66c7880a9d0aee75a1afe7541097e249f"
 }
 x-maintenance-intent: ["(latest)"]
+install: ["dune" "install" "-x" "windows" "-p" "cmdliner"]

--- a/packages/cohttp-lwt-unix-windows/cohttp-lwt-unix-windows.6.1.0/opam
+++ b/packages/cohttp-lwt-unix-windows/cohttp-lwt-unix-windows.6.1.0/opam
@@ -43,17 +43,8 @@ depends: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "cohttp-lwt-unix"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "cohttp-lwt-unix" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -64,3 +55,4 @@ url {
   ]
 }
 x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"
+install: ["dune" "install" "-x" "windows" "-p" "cohttp-lwt-unix"]

--- a/packages/cohttp-lwt-windows/cohttp-lwt-windows.6.1.0/opam
+++ b/packages/cohttp-lwt-windows/cohttp-lwt-windows.6.1.0/opam
@@ -37,17 +37,8 @@ depends: [
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "cohttp-lwt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "cohttp-lwt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -58,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"
+install: ["dune" "install" "-x" "windows" "-p" "cohttp-lwt"]

--- a/packages/cohttp-server-lwt-unix-windows/cohttp-server-lwt-unix-windows.6.1.0/opam
+++ b/packages/cohttp-server-lwt-unix-windows/cohttp-server-lwt-unix-windows.6.1.0/opam
@@ -38,6 +38,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -48,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"
+install: ["dune" "install" "-x" "windows" "-p" "cohttp-server-lwt-unix"]

--- a/packages/cohttp-windows/cohttp-windows.6.1.0/opam
+++ b/packages/cohttp-windows/cohttp-windows.6.1.0/opam
@@ -48,17 +48,8 @@ depends: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "cohttp"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "cohttp" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -69,3 +60,4 @@ url {
   ]
 }
 x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"
+install: ["dune" "install" "-x" "windows" "-p" "cohttp"]

--- a/packages/conduit-lwt-unix-windows/conduit-lwt-unix-windows.8.0.0/opam
+++ b/packages/conduit-lwt-unix-windows/conduit-lwt-unix-windows.8.0.0/opam
@@ -26,6 +26,7 @@ conflicts: [
 ]
 build: [
   ["dune" "build" "-p" "conduit-lwt-unix" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library for Lwt_unix"
@@ -39,3 +40,4 @@ url {
   ]
 }
 x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"
+install: ["dune" "install" "-x" "windows" "-p" "conduit-lwt-unix"]

--- a/packages/conduit-lwt-windows/conduit-lwt-windows.8.0.0/opam
+++ b/packages/conduit-lwt-windows/conduit-lwt-windows.8.0.0/opam
@@ -17,6 +17,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "conduit-lwt" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A portable network connection establishment library using Lwt"
@@ -30,3 +31,4 @@ url {
   ]
 }
 x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"
+install: ["dune" "install" "-x" "windows" "-p" "conduit-lwt"]

--- a/packages/conduit-windows/conduit-windows.8.0.0/opam
+++ b/packages/conduit-windows/conduit-windows.8.0.0/opam
@@ -21,6 +21,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "conduit" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 synopsis: "A network connection establishment library"
@@ -55,3 +56,4 @@ url {
   ]
 }
 x-commit-hash: "cb1e6cfed4a24bf3fa49627424fb9d43bdc20d0f"
+install: ["dune" "install" "-x" "windows" "-p" "conduit"]

--- a/packages/containers-windows/containers-windows.3.16/opam
+++ b/packages/containers-windows/containers-windows.3.16/opam
@@ -17,6 +17,7 @@ depopts: ["base-unix" "base-threads"]
 dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
 build: [
   ["dune" "build" "-p" "containers" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -27,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "99dba20fa6ba0f2db4b9b9ae2acbf4185fa502f4"
+install: ["dune" "install" "-x" "windows" "-p" "containers"]

--- a/packages/core-windows/core-windows.v0.16.1/opam
+++ b/packages/core-windows/core-windows.v0.16.1/opam
@@ -11,6 +11,7 @@ patches: [
 ]
 build: [
   ["dune" "build" "-p" "core" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"               {>= "4.14.0"}
@@ -64,3 +65,4 @@ url {
 extra-files: [
   "patches/no-endian-header.patch" "md5=1398b42006ed9109a2b3c05b98739f65"
 ]
+install: ["dune" "install" "-x" "windows" "-p" "core"]

--- a/packages/core-windows/core-windows.v0.17.1/opam
+++ b/packages/core-windows/core-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "core" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"               {>= "5.1.0"}
@@ -60,3 +61,4 @@ url {
     "sha512=61b415f4fb12c78d30649fff1aabe3a475eea926ce6edb7774031f4dc7f37ea51f5d9337ead6ec73cd93da5fd1ed0f2738c210c71ebc8fe9d7f6135a06bd176f"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "core"]

--- a/packages/core_kernel-windows/core_kernel-windows.v0.16.0/opam
+++ b/packages/core_kernel-windows/core_kernel-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "core_kernel" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"        {>= "4.14.0"}
@@ -33,3 +34,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_kernel-v0.16.0.tar.gz"
 checksum: "sha256=e37370bad978cfb71fdaf2b1a25ab1506b98ef0b91e0dbd189ffd9d853245ce2"
 }
+install: ["dune" "install" "-x" "windows" "-p" "core_kernel"]

--- a/packages/cry-windows/cry-windows.0.6.5/opam
+++ b/packages/cry-windows/cry-windows.0.6.5/opam
@@ -18,17 +18,8 @@ conflicts: [
   "ssl-windows" {< "0.5.9"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "cry"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "cry" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=43de3513ee2a0f5e5ad496f48137519de270f836081870b48768e45146a4aab84ad7a0781eac56f7b69ce8724a7fd49e7f9fd9d2d771f133aeef2db96d7254af"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "cry"]

--- a/packages/cry-windows/cry-windows.0.6.6/opam
+++ b/packages/cry-windows/cry-windows.0.6.6/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "cry"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "cry" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=07e2b76cf061b67fc6e822d6a05497cc3de06d7c9eeb3cf16c596486a9f452d6a77139928baa43c6aa5759fb851ba290f8189f0e7e9e093585f89df2715497ff"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "cry"]

--- a/packages/cry-windows/cry-windows.1.0.1/opam
+++ b/packages/cry-windows/cry-windows.1.0.1/opam
@@ -14,17 +14,8 @@ depends: [
   "base-bytes"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "cry"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "cry" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
 url {
@@ -34,3 +25,4 @@ url {
     "sha512=34e8fe3dc9fe61f3a20e84940e9cc23d2a936717ae410b04d26e75ac655e2d7c5b20f549dd706ef0594f448680bd63d9a3cc68e95d5ac82b067b82bd96ce68ec"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "cry"]

--- a/packages/cry-windows/cry-windows.1.0.2/opam
+++ b/packages/cry-windows/cry-windows.1.0.2/opam
@@ -29,6 +29,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-cry.git"
 url {
@@ -38,3 +39,4 @@ url {
     "sha512=bfbd7e585f0a2e552b128a24094e1eb06281d3a332c143a1d6551ec005551add338668553df057346433f378416da7fe3e3289d21b8aa0244f15c509d8d8d0fa"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "cry"]

--- a/packages/csexp-windows/csexp-windows.1.5.2/opam
+++ b/packages/csexp-windows/csexp-windows.1.5.2/opam
@@ -33,17 +33,8 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "csexp"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "csexp" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -54,3 +45,4 @@ url {
   ]
 }
 x-commit-hash: "e6c4768e10c61bcb04d09748744dad55602149c6"
+install: ["dune" "install" "-x" "windows" "-p" "csexp"]

--- a/packages/cstruct-windows/cstruct-windows.5.1.1/opam
+++ b/packages/cstruct-windows/cstruct-windows.5.1.1/opam
@@ -13,6 +13,7 @@ tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "cstruct" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.03.0"}
@@ -34,3 +35,4 @@ url {
     "sha512=c3aa9a5a9125a1d022506a76fd7cdf32b21edcdc9df1202d8a9f382d02a28a33fea9a958f79e9302907ade1fce3f166b620c320aed6486e3efcc9a7464379cab"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "cstruct"]

--- a/packages/csv-windows.2.4/opam
+++ b/packages/csv-windows.2.4/opam
@@ -12,6 +12,7 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "csv" "-x" "windows" "-j" jobs]
   ["dune" "runtest" "-p" "csv" "-x" "windows" "-j" jobs] {with-test}
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
@@ -34,3 +35,4 @@ url {
     "sha512=a8a952315950fc7fcca36c758b69618296060fd4eab3140ac364ad62172cf665b3c0c9d892ddb586929217466a42f33f432e32e3bd0c1e549ea22bef6ef8a900"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "csv.2.4"]

--- a/packages/ctypes-foreign-windows/ctypes-foreign-windows.0.22.0/opam
+++ b/packages/ctypes-foreign-windows/ctypes-foreign-windows.0.22.0/opam
@@ -19,17 +19,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ctypes-foreign"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ctypes-foreign" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 extra-files: [
   ["patches/fix-config.patch" "md5=aabfea16327b5549e9a559f3ae99ba21"]
@@ -45,3 +36,4 @@ url {
   src: "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.22.0.tar.gz"
   checksum: "md5=8a301a3e3b79156448a6659859ad506c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ctypes-foreign"]

--- a/packages/ctypes-windows/ctypes-windows.0.22.0/opam
+++ b/packages/ctypes-windows/ctypes-windows.0.22.0/opam
@@ -35,20 +35,12 @@ depends: [
   "bigarray-compat-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ctypes"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ctypes" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
 url {
   src: "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.22.0.tar.gz"
   checksum: "md5=8a301a3e3b79156448a6659859ad506c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ctypes"]

--- a/packages/curl-windows/curl-windows.0.9.2/opam
+++ b/packages/curl-windows/curl-windows.0.9.2/opam
@@ -8,22 +8,14 @@ dev-repo: "git+https://github.com/ygrek/ocurl.git"
 bug-reports: "https://github.com/ygrek/ocurl/issues"
 tags: ["org:ygrek" "clib:curl"]
 build: [
-  [ "./configure"
+  [
+    "./configure"
     "--host=%{conf-gcc-windows:host}%"
     "--prefix=%{prefix}%"
     "OCAMLFIND_TOOLCHAIN=windows"
   ]
-  [
-    "dune"
-    "build"
-    "-p"
-    "curl"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "curl" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 patches: [
   "patches/undef.patch"
@@ -47,3 +39,4 @@ description: "libcurl is a client-side URL transfer library, supporting HTTP and
 url {
   src: "git+https://github.com/ygrek/ocurl.git#1bc75b8"
 }
+install: ["dune" "install" "-x" "windows" "-p" "curl"]

--- a/packages/decompress-windows/decompress-windows.1.1.0/opam
+++ b/packages/decompress-windows/decompress-windows.1.1.0/opam
@@ -12,8 +12,17 @@ description: """Decompress is an implementation of Zlib and GZip in OCaml
 It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
-build: [ "dune" "build" "-p" "decompress" "-j" jobs "-x" "windows" ]
-
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "decompress"
+  "-j"
+  jobs
+  "-x"
+  "windows"]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows"
   "dune"
@@ -29,3 +38,4 @@ url {
     "sha512=abb4994150ef724b4cbf0612e0215092818139a5eca33c2365b6fdac61e4e33323da490fd8ea1adf8348c136b11a6448b1500173352f7b61f7641d32c02f3874"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "decompress"]

--- a/packages/digestif-windows/digestif-windows.1.2.0/opam
+++ b/packages/digestif-windows/digestif-windows.1.2.0/opam
@@ -30,11 +30,10 @@ We provides implementation of:
 """
 
 build: [
-  [ "dune" "build" "-p" "digestif" "-x" "windows" "-j" jobs ]
+  ["dune" "build" "-p" "digestif" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-install:  [
-]
-
+install: ["dune" "install" "-x" "windows" "-p" "digestif"]
 depends: [
   "ocaml-windows"
   "dune"            {>= "2.6.0"}

--- a/packages/domain-name-windows/domain-name-windows.0.4.1/opam
+++ b/packages/domain-name-windows/domain-name-windows.0.4.1/opam
@@ -11,6 +11,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "domain-name" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/hannesm/domain-name.git"
 synopsis: "RFC 1035 Internet domain names"
@@ -32,3 +33,4 @@ url {
   ]
 }
 x-commit-hash: "26c8a60f57d73e5f767ca8049dba29ca0a214d55"
+install: ["dune" "install" "-x" "windows" "-p" "domain-name"]

--- a/packages/domain_shims-windows/domain_shims-windows.0.1.0/opam
+++ b/packages/domain_shims-windows/domain_shims-windows.0.1.0/opam
@@ -11,7 +11,17 @@ depends: [
   "ocaml-windows" {>= "4.12"}
   "dune" {>= "3.0"}
 ]
-build: ["dune" "build" "-p" "domain_shims" "-x" "windows" "-j" jobs]
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "domain_shims"
+  "-x"
+  "windows"
+  "-j"
+  jobs]
+  ["rm" "%{name}%.install"]
+]
 url {
   src:
     "https://gitlab.com/gasche/domain-shims/-/archive/0.1.0/domain-shims-0.1.0.tar.gz"
@@ -20,3 +30,4 @@ url {
     "sha512=aef52e40ce48623a4679116d4f1008e333ef28ed4dee81a30dd3e5858745bde2d5045b89add71090282c281578b9b90cc7730253490e0fef00074ee78d36dbef"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "domain_shims"]

--- a/packages/dtools-windows/dtools-windows.0.4.2/opam
+++ b/packages/dtools-windows/dtools-windows.0.4.2/opam
@@ -10,17 +10,8 @@ depends: [
   "dune" {>= "2.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "dtools"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "dtools" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 url {
@@ -30,3 +21,4 @@ url {
     "sha512=abd158530fc136598e6fdba6c70cc433984ef5d5e9abda80e1f5ac1b6975869b99cdff62dba96510f1bd64b4035ac7c8462a7e0a801a55158bf3204fb2771869"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dtools"]

--- a/packages/dtools-windows/dtools-windows.0.4.4/opam
+++ b/packages/dtools-windows/dtools-windows.0.4.4/opam
@@ -10,17 +10,8 @@ depends: [
   "dune" {>= "2.8"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "dtools"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "dtools" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 url {
@@ -30,3 +21,4 @@ url {
     "sha512=8416c3bfc49de7bfb92e6921c37512882589f3b7a6b9f51cb75e761697204b99a37827028a828861134c067a2efc06e80073dc0b5f5fb6529c7f4ff04f957984"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dtools"]

--- a/packages/dtools-windows/dtools-windows.0.4.5/opam
+++ b/packages/dtools-windows/dtools-windows.0.4.5/opam
@@ -12,17 +12,8 @@ depends: [
 ]
 depopts: ["syslog"]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "dtools"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "dtools" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 url {
@@ -33,3 +24,4 @@ url {
     "sha512=096ffdfc8ba04add0e106034d9f739b841763b28e05f947dc975665ce8ce6e7a66084f67e27e9843e07079588d1640f5077b0073427b614dc061d2a02ef323b5"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dtools"]

--- a/packages/dtools-windows/dtools-windows.0.4.6/opam
+++ b/packages/dtools-windows/dtools-windows.0.4.6/opam
@@ -13,17 +13,8 @@ depends: [
 depopts: ["syslog"]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "dtools"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "dtools" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 url {
@@ -34,3 +25,4 @@ url {
     "sha512=ceb00c45909c75590c4cbdd1f96461009f56c068cf6206153ab7e8c75e6e5f07119624f70bda8a265a93659d7036c4523a66ce2113e7edf576e26064e153fe9d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dtools"]

--- a/packages/dune-action-plugin-windows/dune-action-plugin-windows.2.5.1/opam
+++ b/packages/dune-action-plugin-windows/dune-action-plugin-windows.2.5.1/opam
@@ -36,6 +36,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src: "https://github.com/ocaml/dune/releases/download/2.5.1/dune-2.5.1.tbz"
@@ -44,3 +45,4 @@ url {
     "sha512=f209f12ced10c1abf8782bdb0143f4cec77795f7174d2cc75130afb1e01550b01f2f77b9e3ec4888efdad83d2f9878d179b39126f824f4e522f3ef4da34bf27e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dune-action-plugin"]

--- a/packages/dune-build-info-windows/dune-build-info-windows.2.5.1/opam
+++ b/packages/dune-build-info-windows/dune-build-info-windows.2.5.1/opam
@@ -32,6 +32,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src: "https://github.com/ocaml/dune/releases/download/2.5.1/dune-2.5.1.tbz"
@@ -40,3 +41,4 @@ url {
     "sha512=f209f12ced10c1abf8782bdb0143f4cec77795f7174d2cc75130afb1e01550b01f2f77b9e3ec4888efdad83d2f9878d179b39126f824f4e522f3ef4da34bf27e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dune-build-info"]

--- a/packages/dune-build-info-windows/dune-build-info-windows.3.2.0/opam
+++ b/packages/dune-build-info-windows/dune-build-info-windows.3.2.0/opam
@@ -33,6 +33,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -43,3 +44,4 @@ url {
   ]
 }
 x-commit-hash: "43af00f79e41ce9101d42b36dab13e1f68d49a7a"
+install: ["dune" "install" "-x" "windows" "-p" "dune-build-info"]

--- a/packages/dune-configurator-windows/dune-configurator-windows.3.19.1/opam
+++ b/packages/dune-configurator-windows/dune-configurator-windows.3.19.1/opam
@@ -37,6 +37,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -47,3 +48,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "dune-configurator"]

--- a/packages/dune-glob-windows/dune-glob-windows.2.5.1/opam
+++ b/packages/dune-glob-windows/dune-glob-windows.2.5.1/opam
@@ -27,6 +27,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src: "https://github.com/ocaml/dune/releases/download/2.5.1/dune-2.5.1.tbz"
@@ -35,3 +36,4 @@ url {
     "sha512=f209f12ced10c1abf8782bdb0143f4cec77795f7174d2cc75130afb1e01550b01f2f77b9e3ec4888efdad83d2f9878d179b39126f824f4e522f3ef4da34bf27e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "dune-glob"]

--- a/packages/dune-private-libs-windows/dune-private-libs-windows.3.19.1/opam
+++ b/packages/dune-private-libs-windows/dune-private-libs-windows.3.19.1/opam
@@ -39,6 +39,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -49,3 +50,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "dune-private-libs"]

--- a/packages/dune-site-windows/dune-site-windows.3.19.1/opam
+++ b/packages/dune-site-windows/dune-site-windows.3.19.1/opam
@@ -15,17 +15,8 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["rm" "-rf" "vendor/csexp"]
   ["rm" "-rf" "vendor/pp"]
-  [
-    "dune"
-    "build"
-    "-p"
-    "dune-site,dyn"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "dune-site,dyn" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -36,3 +27,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "dune-site"]

--- a/packages/dune-windows/dune-windows.3.19.1/opam
+++ b/packages/dune-windows/dune-windows.3.19.1/opam
@@ -28,7 +28,16 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"
 x-maintenance-intent: ["(latest)"]
 build: [
-  ["dune" "build" "-x" "windows" "-p" "ordering,stdune,xdg,dyn,dune-rpc,chrome-trace,dune-build-info,ocamlc-loc,dune-private-libs,dune-action-plugin,dune-glob,dune-site,dune" "@install"]
+  [
+    "dune"
+    "build"
+    "-x"
+    "windows"
+    "-p"
+    "ordering,stdune,xdg,dyn,dune-rpc,chrome-trace,dune-build-info,ocamlc-loc,dune-private-libs,dune-action-plugin,dune-glob,dune-site,dune"
+    "@install"
+  ]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune"
@@ -49,3 +58,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "dune"]

--- a/packages/duppy-windows/duppy-windows.0.9.0/opam
+++ b/packages/duppy-windows/duppy-windows.0.9.0/opam
@@ -10,17 +10,8 @@ depends: [
   "pcre-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "duppy"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "duppy" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 url {
@@ -30,3 +21,4 @@ url {
     "sha512=f847e1ad9ff36f6107d4518296ba794085e8897539c4fb7ba98d3709708bd069b0467465a939bf6738966192219d9bc64eee9db40c55be8195df24390570eb3f"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "duppy"]

--- a/packages/duppy-windows/duppy-windows.0.9.1/opam
+++ b/packages/duppy-windows/duppy-windows.0.9.1/opam
@@ -24,6 +24,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 url {
@@ -33,3 +34,4 @@ url {
     "sha512=f802a6d82f54970ef10d0a76cf8989cfcba509e10b4b04b0d0a3eac24c4a488d56f899fa92d879a52d82c139dc0d3dcd61d9cffa43d163dc6e3abc3840f3de67"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "duppy"]

--- a/packages/duppy-windows/duppy-windows.0.9.2/opam
+++ b/packages/duppy-windows/duppy-windows.0.9.2/opam
@@ -10,17 +10,8 @@ depends: [
   "pcre-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "duppy"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "duppy" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 url {
@@ -30,3 +21,4 @@ url {
     "sha512=380947d4fa4d03c46ad5de82d8e9fbbd1fe3f0489ca7d3ef14de28f65aa189128a5496a194a35f833d29b0e7f32a4b90da76c68b83b729c536991c47fc4813b4"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "duppy"]

--- a/packages/duppy-windows/duppy-windows.0.9.3/opam
+++ b/packages/duppy-windows/duppy-windows.0.9.3/opam
@@ -13,17 +13,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "duppy"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "duppy" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 url {
@@ -34,3 +25,4 @@ url {
     "sha512=a28afdf46521b3c3e4730af142dc24a7cdd7073857f30e394737caf5ca17afb97374078c2d54cfd9a5016d73203f03d5bd43d74e8c5fc96599dc6c81d861738a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "duppy"]

--- a/packages/duppy-windows/duppy-windows.0.9.4/opam
+++ b/packages/duppy-windows/duppy-windows.0.9.4/opam
@@ -14,17 +14,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "duppy"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "duppy" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
 url {
@@ -35,3 +26,4 @@ url {
     "sha512=c2167c6217fd14b51e77cdc5d818907b6957c099892a7a8c2ce6b1a46daa05b753062930002575744315b5363f05bc56832792f8968da19c75aa8da3ee338e70"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "duppy"]

--- a/packages/duration-windows/duration-windows.0.2.1/opam
+++ b/packages/duration-windows/duration-windows.0.2.1/opam
@@ -11,6 +11,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "duration" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/hannesm/duration.git"
 synopsis: "Conversions to various time units"
@@ -29,3 +30,4 @@ url {
 }
 x-commit-hash: "6abe42ebe585a96f79eb91045911b9a73c1db19e"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "duration"]

--- a/packages/dyn-windows/dyn-windows.3.19.1/opam
+++ b/packages/dyn-windows/dyn-windows.3.19.1/opam
@@ -18,17 +18,8 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["rm" "-rf" "vendor/csexp"]
   ["rm" "-rf" "vendor/pp"]
-  [
-    "dune"
-    "build"
-    "-p"
-    "dyn"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "dyn" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -39,3 +30,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "dyn"]

--- a/packages/easy-format-windows/easy-format-windows.1.3.4/opam
+++ b/packages/easy-format-windows/easy-format-windows.1.3.4/opam
@@ -30,17 +30,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "easy-format"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "easy-format" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/easy-format.git"
 url {
@@ -52,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "ba4962884509ceec63905dd6e0ccb429be4f9f66"
+install: ["dune" "install" "-x" "windows" "-p" "easy-format"]

--- a/packages/either-windows/either-windows.1.0.0/opam
+++ b/packages/either-windows/either-windows.1.0.0/opam
@@ -16,17 +16,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "either"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "either" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/either.git"
 x-commit-hash: "a270ceac58e3e5bed6fe7e8bfb7132b14ee9c322"
@@ -38,3 +29,4 @@ url {
     "sha512=147854c09f897dd028b18a9f19acea8666107aaa7b1aab3c92f568af531364f57298edcaf3897d74246d3857d52e9bfb7ad0fc39220d988d9f14694ca1d5e9ed"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "either"]

--- a/packages/eqaf-windows/eqaf-windows.0.10/opam
+++ b/packages/eqaf-windows/eqaf-windows.0.10/opam
@@ -12,9 +12,9 @@ This package provides an equal function on string in constant-time to avoid timi
 """
 
 build: [
-  [ "dune" "build" "-p" "eqaf" "-x" "windows" "-j" jobs ]
+  ["dune" "build" "-p" "eqaf" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows"
   "dune"           {>= "2.0"}
@@ -27,3 +27,4 @@ url {
   ]
 }
 x-commit-hash: "7bec047f8bfa1a233d24fc4a4b77e8eb18988155"
+install: ["dune" "install" "-x" "windows" "-p" "eqaf"]

--- a/packages/ezjsonm-windows/ezjsonm-windows.1.1.0/opam
+++ b/packages/ezjsonm-windows/ezjsonm-windows.1.1.0/opam
@@ -17,6 +17,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "ezjsonm" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ezjsonm.git"
 synopsis: "Simple interface on top of the Jsonm JSON library"
@@ -34,3 +35,4 @@ url {
     "https://github.com/mirage/ezjsonm/releases/download/v1.1.0/ezjsonm-v1.1.0.tbz"
   checksum: "md5=e8f207c6cd2226b2c4784b1e56556797"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ezjsonm"]

--- a/packages/faad-windows/faad-windows.0.5.0/opam
+++ b/packages/faad-windows/faad-windows.0.5.0/opam
@@ -12,17 +12,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "faad"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "faad" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-faad.git"
 depexts: [
@@ -35,3 +26,4 @@ url {
     "sha512=0983cdf7552f03f021ca20e86ed6ebc67419db8900dd0e3fc316c18af83851259d91b8829092a2e1e307638ce31d6c3ee4810889f43632070122ee24e7971874"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "faad"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.0.2/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.0.2/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +32,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.1/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.1/opam
@@ -19,17 +19,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -42,3 +33,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.10/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.10/opam
@@ -20,17 +20,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -41,3 +32,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.2/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.2/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av" 
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +32,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.4/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.4/opam
@@ -17,17 +17,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.8/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.1.8/opam
@@ -17,17 +17,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.2.1/opam
+++ b/packages/ffmpeg-av-windows/ffmpeg-av-windows.1.2.1/opam
@@ -26,17 +26,8 @@ extra-files: [
   ["patches/strndup.patch" "md5=cdc142e1df3c89fc16040806a3c8da38"]
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-av"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-av" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -47,3 +38,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-av"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.0.2/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.0.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-x"
-    "windows" 
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.1/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.1/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +32,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.10/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.10/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.2/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.4/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.4/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -39,3 +30,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.8/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.1.8/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -37,3 +28,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.2.1/opam
+++ b/packages/ffmpeg-avcodec-windows/ffmpeg-avcodec-windows.1.2.1/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avcodec"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avcodec" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avcodec"]

--- a/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.1/opam
+++ b/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.1/opam
@@ -24,17 +24,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avdevice"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avdevice" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -47,3 +38,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avdevice"]

--- a/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.10/opam
+++ b/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.10/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avdevice"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avdevice" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avdevice"]

--- a/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.2/opam
+++ b/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avdevice" 
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avdevice" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avdevice"]

--- a/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.4/opam
+++ b/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.4/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avdevice"
-    "-x"
-    "windows" 
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avdevice" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -39,3 +30,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avdevice"]

--- a/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.8/opam
+++ b/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.1.8/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avdevice"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avdevice" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -37,3 +28,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avdevice"]

--- a/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.2.1/opam
+++ b/packages/ffmpeg-avdevice-windows/ffmpeg-avdevice-windows.1.2.1/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avdevice"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avdevice" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avdevice"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.0.2/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.0.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.1/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.1/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +32,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.10/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.10/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.2/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.4/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.4/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter" 
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -39,3 +30,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.8/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.1.8/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.2.1/opam
+++ b/packages/ffmpeg-avfilter-windows/ffmpeg-avfilter-windows.1.2.1/opam
@@ -25,17 +25,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avfilter"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avfilter" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -46,3 +37,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avfilter"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.0.2/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.0.2/opam
@@ -16,17 +16,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -39,3 +30,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.1/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.1/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.10/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.10/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.2/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.4/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.4/opam
@@ -15,17 +15,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil" 
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -38,3 +29,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.8/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.1.8/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -37,3 +28,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.2.1/opam
+++ b/packages/ffmpeg-avutil-windows/ffmpeg-avutil-windows.1.2.1/opam
@@ -25,17 +25,8 @@ extra-files: [
   ["patches/strndup.patch" "md5=08f071e74e62aa8ce837e954570ec598"]
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-avutil"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-avutil" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -46,3 +37,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-avutil"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.0.2/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.0.2/opam
@@ -29,6 +29,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +42,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.1/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.1/opam
@@ -30,6 +30,7 @@ build: [
     "windows"
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -42,3 +43,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.10/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.10/opam
@@ -31,6 +31,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -41,3 +42,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.2/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.2/opam
@@ -29,6 +29,7 @@ build: [
     "windows"
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +42,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.4/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.4/opam
@@ -21,13 +21,14 @@ build: [
     "dune"
     "build"
     "-p"
-    "ffmpeg-swresample" 
+    "ffmpeg-swresample"
     "-x"
     "windows"
     "-j"
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +41,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.8/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.1.8/opam
@@ -28,6 +28,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -38,3 +39,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.2.1/opam
+++ b/packages/ffmpeg-swresample-windows/ffmpeg-swresample-windows.1.2.1/opam
@@ -31,6 +31,7 @@ build: [
     jobs
     "@install"
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -41,3 +42,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swresample"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.0.2/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.0.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"
-    "-x"
-    "windows"  
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.1/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.1/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -41,3 +32,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.10/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.10/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.2/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.2/opam
@@ -17,17 +17,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"    
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -40,3 +31,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.4/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.4/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"
-    "-x"
-    "windows" 
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -39,3 +30,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.8/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.1.8/opam
@@ -16,17 +16,8 @@ conflicts: [
   "ffmpeg-windows" {< "0.5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -37,3 +28,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.2.1/opam
+++ b/packages/ffmpeg-swscale-windows/ffmpeg-swscale-windows.1.2.1/opam
@@ -19,17 +19,8 @@ depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg-swscale"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg-swscale" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -40,3 +31,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg-swscale"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.0.2/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.0.2/opam
@@ -17,17 +17,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -37,3 +28,4 @@ url {
     "sha512=17740d7d7148fc460066dc65b6d665b1efb541aca379986f42acc3975d76db656e08a822d0035d351efd2c371b0878603bb3c66c612123b229bc2dda15e25c9a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.1.1/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.1.1/opam
@@ -19,17 +19,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -42,3 +33,4 @@ url {
     "sha512=a94a21c73661b3ee9bcc8a9d6539693977b18c4fa1065701fc7b00cf0f148c154dc6b21790193fae157dbded811e28538cbe8e8fb7bcf426900d30d453225d50"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.1.10/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.1.10/opam
@@ -17,17 +17,8 @@ depends: [
   "ffmpeg-swresample-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=f4d35e93d847b2a00965ab6a8ef33698612eb77f7667477ee3308ef192ecc082787ef26ac5dae2bee12c579ef36028a66e698fe3de46309ac2bd90e5ba09314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.1.2/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.1.2/opam
@@ -20,17 +20,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ffmpeg"] {os-distribution = "mxe"}
@@ -43,3 +34,4 @@ url {
     "sha512=e7038dca9b42f44743ad16ca2de86c3a57f310dac2d7d6143c9c82ec9097b024e7c8ec78d40526fa4a675b83e5d73b44419ba2128453c808f66416e66c60a461"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.1.4/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.1.4/opam
@@ -18,17 +18,8 @@ depends: [
   "ffmpeg-swresample-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=1274f0e4c5504e6afd522a50682ed1b2b63a1fd0d174d928c97e7e57cebf1a7714b2b019dfe1f29952a7ff5b8d2c25d10590aa893c5b2d66cb8e845a59323bd9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.1.8/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.1.8/opam
@@ -18,17 +18,8 @@ depends: [
   "ffmpeg-swresample-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -39,3 +30,4 @@ url {
     "sha512=8ccbb5f48f9d827520cf5bf8527c95ec50fa016952b816a174385f94263b2a3692b2f49f7d0cab8ce6f07a6fd7b6073595e0e8ac5aa8bc7f61e09d36002e2bc2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/ffmpeg-windows/ffmpeg-windows.1.2.1/opam
+++ b/packages/ffmpeg-windows/ffmpeg-windows.1.2.1/opam
@@ -17,17 +17,8 @@ depends: [
   "ffmpeg-swresample-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ffmpeg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ffmpeg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=c72adb6ba5651e47c343d28b6be7759a5958ea1ea712ce98d3d4b86de35370f79e8c4833aa35b0633907d813abc080f6472186ad433ff5b8eeb31d5b5e012913"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ffmpeg"]

--- a/packages/fieldslib-windows/fieldslib-windows.v0.12.0/opam
+++ b/packages/fieldslib-windows/fieldslib-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "fieldslib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/fieldslib-v0.12.0.tar.gz"
   checksum: "md5=7cb44f0fb396b6645fc9965ebb8e6741"
 }
+install: ["dune" "install" "-x" "windows" "-p" "fieldslib"]

--- a/packages/fieldslib-windows/fieldslib-windows.v0.14.0/opam
+++ b/packages/fieldslib-windows/fieldslib-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "fieldslib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/fieldslib-v0.14.0.tar.gz"
   checksum: "md5=4fbf05d88be119e883abecba8c33cb85"
 }
+install: ["dune" "install" "-x" "windows" "-p" "fieldslib"]

--- a/packages/fieldslib-windows/fieldslib-windows.v0.16.0/opam
+++ b/packages/fieldslib-windows/fieldslib-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "fieldslib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/fieldslib-v0.16.0.tar.gz"
 checksum: "sha256=2cc5954259e71a747dfaad0e86bfe32c04dca35e83372dbcdeefb08c6059b2f1"
 }
+install: ["dune" "install" "-x" "windows" "-p" "fieldslib"]

--- a/packages/fieldslib-windows/fieldslib-windows.v0.17.0/opam
+++ b/packages/fieldslib-windows/fieldslib-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "fieldslib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/fieldslib/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=3d6001f7355d2dfb0f33fb7e64f39e34bda0917277609f5ec9a0703aa17b7dfa"
 }
+install: ["dune" "install" "-x" "windows" "-p" "fieldslib"]

--- a/packages/fileutils-windows/fileutils-windows.0.6.1/opam
+++ b/packages/fileutils-windows/fileutils-windows.0.6.1/opam
@@ -9,6 +9,7 @@ doc: "https://gildor478.github.io/ocaml-fileutils/"
 
 build: [
   ["dune" "build" "-p" "fileutils" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.03"}
@@ -44,3 +45,4 @@ url {
   ]
 }
 
+install: ["dune" "install" "-x" "windows" "-p" "fileutils"]

--- a/packages/fileutils-windows/fileutils-windows.0.6.4/opam
+++ b/packages/fileutils-windows/fileutils-windows.0.6.4/opam
@@ -9,6 +9,7 @@ doc: "https://gildor478.github.io/ocaml-fileutils/"
 
 build: [
   ["dune" "build" "-p" "fileutils" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.03"}
@@ -44,3 +45,4 @@ url {
   ]
 }
 x-commit-hash: "324a05938d88c4b645287adbf5ceb74f4ce0daec"
+install: ["dune" "install" "-x" "windows" "-p" "fileutils"]

--- a/packages/gel-windows/gel-windows.v0.17.0/opam
+++ b/packages/gel-windows/gel-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/gel/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "gel" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://github.com/janestreet/gel/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=80e3c39fa654d770329d8e2e1bb792e8eb18ceb2dd16fb2d9037830ad73c434f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "gel"]

--- a/packages/gen-windows/gen-windows.0.5.2/opam
+++ b/packages/gen-windows/gen-windows.0.5.2/opam
@@ -11,7 +11,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  ["dune" "build" "-p" "gen" "-x" "windows"  "-j" jobs]
+  ["dune" "build" "-p" "gen" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/c-cube/gen.git"
 url {
@@ -21,3 +22,4 @@ url {
     "sha512=c84e5ea0c9b3a678b6a5c935eacf91265a79b68a48375c44aa5f159d4cb02283c1be0786e172a153666c670bc7ee37b931004b8747a99e5f4ab90ca63e097ff5"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "gen"]

--- a/packages/gen-windows/gen-windows.0.5.3/opam
+++ b/packages/gen-windows/gen-windows.0.5.3/opam
@@ -8,7 +8,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  ["dune" "build" "-p" "gen" "-x" "windows"  "-j" jobs]
+  ["dune" "build" "-p" "gen" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 tags: [ "gen" "iterator" "iter" "fold" ]
 homepage: "https://github.com/c-cube/gen/"
@@ -23,3 +24,4 @@ url {
     "sha512=192178de106d2ae5f936caead8b21b4b9ec1b8fe35ba56296825900ea15a4ea702caf8824ac34d4478d107b954e22c3dffd81f12d4c08fbd6d9760f49a0deb14"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "gen"]

--- a/packages/gen-windows/gen-windows.1.0/opam
+++ b/packages/gen-windows/gen-windows.1.0/opam
@@ -4,6 +4,7 @@ synopsis: "Iterators for OCaml, both restartable and consumable"
 license: "BSD-2-Clause"
 build: [
   ["dune" "build" "@install" "-p" "gen" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "1.1"}
@@ -25,3 +26,4 @@ url {
     "sha512=fb4ec2ab35a1aba0dcc8439b11f14a0a785d939f661f505aec88a6f2ca6ca87e14ddfda860d9c180b215190b76690de87040c144582f069224f7e58d37ef48a0"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "gen"]

--- a/packages/gen-windows/gen-windows.1.1/opam
+++ b/packages/gen-windows/gen-windows.1.1/opam
@@ -4,6 +4,7 @@ synopsis: "Iterators for OCaml, both restartable and consumable"
 license: "BSD-2-Clause"
 build: [
   ["dune" "build" "@install" "-p" "gen" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "1.1"}
@@ -24,3 +25,4 @@ url {
     "sha512=71a4b5c3666a7c11935398a78feea7383f61d2c549dfb96e324d40783ffa87b5ec492c5ec468803aabfb9b48e7d0ebaa30b24d2b974540afc7cca5feea3121c1"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "gen"]

--- a/packages/gmap-windows/gmap-windows.0.3.0/opam
+++ b/packages/gmap-windows/gmap-windows.0.3.0/opam
@@ -11,6 +11,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "gmap" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/hannesm/gmap.git"
 synopsis: "Heterogenous maps over a GADT"
@@ -31,3 +32,4 @@ url {
   ]
 }
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "gmap"]

--- a/packages/grace-windows/grace-windows.0.3.0/opam
+++ b/packages/grace-windows/grace-windows.0.3.0/opam
@@ -27,13 +27,16 @@ build: [
     "dune"
     "build"
     "-p"
-    "grace" "-x" "windows"
+    "grace"
+    "-x"
+    "windows"
     "-j"
     jobs
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/johnyob/grace.git"
 url {
@@ -45,3 +48,4 @@ url {
   ]
 }
 x-commit-hash: "15251666a11a780dfd09f23e1b0c1e6b0e366dcf"
+install: ["dune" "install" "-x" "windows" "-p" "grace"]

--- a/packages/graphics-windows/graphics-windows.5.1.2/opam
+++ b/packages/graphics-windows/graphics-windows.5.1.2/opam
@@ -22,17 +22,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "graphics"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "graphics" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml/graphics.git"
 x-commit-hash: "fbfa38f50f9df5d562d5c892ae12cec2c695776d"
@@ -44,3 +35,4 @@ url {
     "sha512=1387c1ecf5dfd62c3927f1f8ce0bcc8b162ef22f15bfd41eba47c955091f7ce5f19395beab550d31cff38d22c4ad097350975381e60936a0004271e96f65b09b"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "graphics"]

--- a/packages/hex-windows/hex-windows.1.4.0/opam
+++ b/packages/hex-windows/hex-windows.1.4.0/opam
@@ -14,6 +14,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "hex" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-hex.git"
 synopsis: "Library providing hexadecimal converters"
@@ -34,3 +35,4 @@ url {
     "https://github.com/mirage/ocaml-hex/releases/download/v1.4.0/hex-v1.4.0.tbz"
   checksum: "md5=57103ff33e70f14171c46d88f5452d11"
 }
+install: ["dune" "install" "-x" "windows" "-p" "hex"]

--- a/packages/http-windows/http-windows.6.1.0/opam
+++ b/packages/http-windows/http-windows.6.1.0/opam
@@ -26,17 +26,8 @@ depends: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "http"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "http" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -47,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "de25ba68286866577bd8a81c002176cc22dd49e4"
+install: ["dune" "install" "-x" "windows" "-p" "http"]

--- a/packages/int_repr-windows/int_repr-windows.v0.16.0/opam
+++ b/packages/int_repr-windows/int_repr-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/int_repr/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "int_repr" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/int_repr-v0.16.0.tar.gz"
 checksum: "sha256=132f56262ffee171ff81162460c7132ac366f0295a23801795385c3620b6f076"
 }
+install: ["dune" "install" "-x" "windows" "-p" "int_repr"]

--- a/packages/int_repr-windows/int_repr-windows.v0.17.0/opam
+++ b/packages/int_repr-windows/int_repr-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/int_repr/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "int_repr" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://github.com/janestreet/int_repr/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=84834341ee55934dec68f3fb6ea9328092eece8ec7f079ac3eee2a11d08c52df"
 }
+install: ["dune" "install" "-x" "windows" "-p" "int_repr"]

--- a/packages/integers-windows/integers-windows.0.4.0/opam
+++ b/packages/integers-windows/integers-windows.0.4.0/opam
@@ -11,8 +11,8 @@ license: "MIT"
 
 build: [
   ["dune" "build" "-p" "integers" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.02" & < "5.0"}
   "dune"
@@ -23,3 +23,4 @@ url {
   src: "https://github.com/ocamllabs/ocaml-integers/archive/0.4.0.tar.gz"
   checksum: "md5=c1492352e6525048790508c57aad93c3"
 }
+install: ["dune" "install" "-x" "windows" "-p" "integers"]

--- a/packages/integers-windows/integers-windows.0.7.0/opam
+++ b/packages/integers-windows/integers-windows.0.7.0/opam
@@ -11,8 +11,8 @@ license: "MIT"
 
 build: [
   ["dune" "build" "-p" "integers" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.03"}
   "dune" {>= "1.0"}
@@ -25,3 +25,4 @@ url {
   src: "https://github.com/yallop/ocaml-integers/archive/0.7.0.tar.gz"
   checksum: "md5=201cf24143d7cb9a3921d572b6e6c42c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "integers"]

--- a/packages/ipaddr-sexp-windows/ipaddr-sexp-windows.5.6.0/opam
+++ b/packages/ipaddr-sexp-windows/ipaddr-sexp-windows.5.6.0/opam
@@ -21,6 +21,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "ipaddr-sexp" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
 url {
@@ -33,3 +34,4 @@ url {
 }
 x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "ipaddr-sexp"]

--- a/packages/ipaddr-windows/ipaddr-windows.5.6.0/opam
+++ b/packages/ipaddr-windows/ipaddr-windows.5.6.0/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "ipaddr" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
 url {
@@ -46,3 +47,4 @@ url {
 }
 x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "ipaddr"]

--- a/packages/iter-windows/iter-windows.1.9/opam
+++ b/packages/iter-windows/iter-windows.1.9/opam
@@ -6,7 +6,9 @@ synopsis: "Simple abstraction over `iter` functions, intended to iterate efficie
 build: [
   ["dune" "build" "@install" "-p" "iter" "-x" "windows" "-j" jobs]
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+  ["dune" "runtest" "-p" name "-j" jobs]
+    {with-test & arch != "arm32" & arch != "x86_32"}
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" { >= "4.08.0" }
@@ -32,3 +34,4 @@ url {
   ]
 }
 x-commit-hash: "a525d4902c9fb71e6acd84ee1f2ab8e1f3eefb10"
+install: ["dune" "install" "-x" "windows" "-p" "iter"]

--- a/packages/jane-street-headers-windows/jane-street-headers-windows.v0.14.0/opam
+++ b/packages/jane-street-headers-windows/jane-street-headers-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jane-street-headers/ind
 license: "MIT"
 build: [
   ["dune" "build" "-p" "jane-street-headers" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml" {>= "4.04.2"}
@@ -22,3 +23,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/jane-street-headers-v0.14.0.tar.gz"
   checksum: "md5=e8d253ac44d25c8c66367153a0c77495"
 }
+install: ["dune" "install" "-x" "windows" "-p" "jane-street-headers"]

--- a/packages/jane-street-headers-windows/jane-street-headers-windows.v0.16.0/opam
+++ b/packages/jane-street-headers-windows/jane-street-headers-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jane-street-headers/ind
 license: "MIT"
 build: [
   ["dune" "build" "-p" "jane-street-headers" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml" {>= "4.14.0"}
@@ -22,3 +23,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/jane-street-headers-v0.16.0.tar.gz"
 checksum: "sha256=876d409feeb495487b10010fb601c64829d2aa15f1b156b704ec141337d360ea"
 }
+install: ["dune" "install" "-x" "windows" "-p" "jane-street-headers"]

--- a/packages/jane-street-headers-windows/jane-street-headers-windows.v0.17.0/opam
+++ b/packages/jane-street-headers-windows/jane-street-headers-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jane-street-headers/ind
 license: "MIT"
 build: [
   ["dune" "build" "-p" "jane-street-headers" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -22,3 +23,4 @@ url {
 src: "https://github.com/janestreet/jane-street-headers/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=78fa6084cd067b7a7d930d1fe1cb7eb9dcd1a90c73017e570213b47a3762eb4f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "jane-street-headers"]

--- a/packages/jst-config-windows/jst-config-windows.v0.14.1/opam
+++ b/packages/jst-config-windows/jst-config-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jst-config/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "jst-config" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.04.2"}
@@ -33,3 +34,4 @@ url {
   src: "https://github.com/janestreet/jst-config/archive/refs/tags/v0.14.1.tar.gz"
   checksum: "md5=ca0d970356cc99b0a5660058a93ff589"
 }
+install: ["dune" "install" "-x" "windows" "-p" "jst-config"]

--- a/packages/jst-config-windows/jst-config-windows.v0.16.0/opam
+++ b/packages/jst-config-windows/jst-config-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jst-config/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "jst-config" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "4.14.0"}
@@ -31,3 +32,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/jst-config-v0.16.0.tar.gz"
 checksum: "sha256=faead56d8582868cdc099ad54f9bae059cc48710b724600cc64013e73c14d95b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "jst-config"]

--- a/packages/jst-config-windows/jst-config-windows.v0.17.0/opam
+++ b/packages/jst-config-windows/jst-config-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/jst-config/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "jst-config" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
 src: "https://github.com/janestreet/jst-config/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=2cf345e33bed0ee4c325667e77dfc5bee8f12afd56318b7c9acf81ec875ecf6e"
 }
+install: ["dune" "install" "-x" "windows" "-p" "jst-config"]

--- a/packages/kdf-windows/kdf-windows.1.0.0/opam
+++ b/packages/kdf-windows/kdf-windows.1.0.0/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "kdf" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/robur-coop/kdf.git"
 synopsis: "Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914"
@@ -31,3 +32,4 @@ url {
 }
 x-commit-hash: "a6da77f39fd1b3acc6865a9a20dca567a5e1fe89"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "kdf"]

--- a/packages/kqueue-windows/kqueue-windows.0.3.0/opam
+++ b/packages/kqueue-windows/kqueue-windows.0.3.0/opam
@@ -14,17 +14,8 @@ depends: [
   "ocaml-windows" {>= "4.12"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "kqueue"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "kqueue" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/anuragsoni/kqueue-ml.git"
 conflicts: [
@@ -39,3 +30,4 @@ url {
   ]
 }
 x-commit-hash: "dd9e92b2efd0c9d2a87917dd4b4c25bf95f87722"
+install: ["dune" "install" "-x" "windows" "-p" "kqueue"]

--- a/packages/lambdasoup-windows/lambdasoup-windows.0.6.4/opam
+++ b/packages/lambdasoup-windows/lambdasoup-windows.0.6.4/opam
@@ -24,8 +24,8 @@ depends: [
 
 build: [
   ["dune" "build" "-p" "lambdasoup" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 description: """
 Lambda Soup is an HTML scraping library inspired by Python's Beautiful Soup. It
 provides lazy traversals from HTML nodes to their parents, children, siblings,
@@ -43,3 +43,4 @@ url {
   src: "https://github.com/aantron/lambda-soup/archive/0.6.4.tar.gz"
   checksum: "md5=b697aec8575bcc543558d89317e8e047"
 }
+install: ["dune" "install" "-x" "windows" "-p" "lambdasoup"]

--- a/packages/lambdasoup-windows/lambdasoup-windows.0.7.0/opam
+++ b/packages/lambdasoup-windows/lambdasoup-windows.0.7.0/opam
@@ -19,8 +19,8 @@ depends: [
 
 build: [
   ["dune" "build" "-p" "lambdasoup" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 description: """
 Lambda Soup is an HTML scraping library inspired by Python's Beautiful Soup. It
 provides lazy traversals from HTML nodes to their parents, children, siblings,
@@ -38,3 +38,4 @@ url {
   src: "https://github.com/aantron/lambdasoup/archive/0.7.0.tar.gz"
   checksum: "md5=2bb2c7d8a6ac4e12aa7dbdfcbaac0dd8"
 }
+install: ["dune" "install" "-x" "windows" "-p" "lambdasoup"]

--- a/packages/lame-windows/lame-windows.0.3.4/opam
+++ b/packages/lame-windows/lame-windows.0.3.4/opam
@@ -13,17 +13,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "lame"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "lame" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-lame.git"
 depexts: [
@@ -36,3 +27,4 @@ url {
     "sha512=d4737a8e4395bea5d361cc739a9a13aeb41f69b9dfc8e508e3e5b0249ae998fc38a809c7700b0ad95a7bdfb029d3b6c8bede3043e2709336f37c4450f2cda6cc"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lame"]

--- a/packages/lame-windows/lame-windows.0.3.5/opam
+++ b/packages/lame-windows/lame-windows.0.3.5/opam
@@ -27,6 +27,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-lame.git"
 depexts: [
@@ -39,3 +40,4 @@ url {
     "sha512=204753eaa79623549cacc4be5627d8bd3f2bdd33da60026cf0d756637da26f13802f8300957300cca0651a2a2233b7063be20ee72ba45e3c02b8f9f19e54f518"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lame"]

--- a/packages/lame-windows/lame-windows.0.3.7/opam
+++ b/packages/lame-windows/lame-windows.0.3.7/opam
@@ -13,17 +13,8 @@ depends: [
   "dune-configurator"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "lame"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "lame" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-lame.git"
 depexts: [
@@ -37,3 +28,4 @@ url {
     "sha512=7f001c9c04446ca75c23c09f06fb23d6a9d7342bb2aad46e346bf96be189c60a5fea65edf475d4b85f9fe0d136b120d3d5914c5959ed62d006963031701f5af9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lame"]

--- a/packages/lastfm-windows/lastfm-windows.0.3.3/opam
+++ b/packages/lastfm-windows/lastfm-windows.0.3.3/opam
@@ -14,17 +14,8 @@ depends: [
 depopts: ["ocamlnet"]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "lastfm"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "lastfm" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-lastfm.git"
 url {
@@ -34,3 +25,4 @@ url {
     "sha512=2bbd0483719d0ea17862e761651eaccbc8ffa7d264ad03b8b1104077df9398fcfb879bd1914b68dc300c974c4ba3e2161d674cb1579ffd29e1e60f7dd3d3c2db"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lastfm"]

--- a/packages/lastfm-windows/lastfm-windows.0.3.4/opam
+++ b/packages/lastfm-windows/lastfm-windows.0.3.4/opam
@@ -15,17 +15,8 @@ depends: [
 ]
 depopts: ["ocamlnet"]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "lastfm"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "lastfm" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-lastfm.git"
 url {
@@ -36,3 +27,4 @@ url {
     "sha512=49ef0a9257ef9cb2ee90db827bd7025d88bde496499c2193953cea1e9859093fea2d9b1505cc2111757ab82f6f6bd2e7b7abfe8e6df089d0e01b59da129747c6"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lastfm"]

--- a/packages/lwt-windows/lwt-windows.3.2.1/opam
+++ b/packages/lwt-windows/lwt-windows.3.2.1/opam
@@ -18,11 +18,17 @@ patches: [
   "patches/os_type.patch"
 ]
 build: [
-  [ "ocaml" "src/util/configure.ml" "-use-libev" "false" ]
-  [ "dune" "build"
-                        "-x" "windows"
-                       "-p" "lwt" "-j" jobs ]
-  [ "sed" "-r" "-e" "s!(-sysroot/lib/lwt/)(unix|preemptive|log|options|syntax|simple-top|ppx)/!\\1!" "-i" "lwt-windows.install" ]
+  ["ocaml" "src/util/configure.ml" "-use-libev" "false"]
+  ["dune" "build" "-x" "windows" "-p" "lwt" "-j" jobs]
+  [
+    "sed"
+    "-r"
+    "-e"
+    "s!(-sysroot/lib/lwt/)(unix|preemptive|log|options|syntax|simple-top|ppx)/!\\1!"
+    "-i"
+    "lwt-windows.install"
+  ]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {< "4.08.0"}
@@ -46,3 +52,4 @@ url {
   src: "https://github.com/ocsigen/lwt/archive/3.2.1.tar.gz"
   checksum: "md5=13613bbf6b27d198bafcbd9b253a0076"
 }
+install: ["dune" "install" "-x" "windows" "-p" "lwt"]

--- a/packages/lwt-windows/lwt-windows.4.2.1/opam
+++ b/packages/lwt-windows/lwt-windows.4.2.1/opam
@@ -29,8 +29,8 @@ depends: [
 
 build: [
   ["dune" "build" "-x" "windows" "-p" "lwt" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 description: "A promise is a value that may become determined in the future.
 
 Lwt provides typed, composable promises. Promises that are resolved by I/O are
@@ -44,3 +44,4 @@ url {
   src: "https://github.com/ocsigen/lwt/archive/4.2.1.tar.gz"
   checksum: "md5=9d648386ca0a9978eb9487de36b781cc"
 }
+install: ["dune" "install" "-x" "windows" "-p" "lwt"]

--- a/packages/lwt-windows/lwt-windows.5.9.0/opam
+++ b/packages/lwt-windows/lwt-windows.5.9.0/opam
@@ -30,17 +30,8 @@ depends: [
 depopts: ["conf-libev-windows"]
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "lwt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "lwt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.9.0.tar.gz"
@@ -49,3 +40,4 @@ url {
     "sha512=35574743df40170a8d1676254952c060090421a40d5f8ad37a6691f4f8bb0e28fca61f5efff1050edc4f8a3ffa2f06a1e23d0c084c89bfc105c1235e249bbc75"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lwt"]

--- a/packages/lwt_react-windows/lwt_react-windows.1.2.0/opam
+++ b/packages/lwt_react-windows/lwt_react-windows.1.2.0/opam
@@ -24,6 +24,7 @@ depends: [
 
 build: [
   ["dune" "build" "-p" "lwt_react" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
@@ -32,3 +33,4 @@ url {
     "sha512=d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "lwt_react"]

--- a/packages/lwt_ssl-windows/lwt_ssl-windows.1.2.0/opam
+++ b/packages/lwt_ssl-windows/lwt_ssl-windows.1.2.0/opam
@@ -22,6 +22,7 @@ depends: [
 
 build: [
   ["dune" "build" "-p" "lwt_ssl" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -32,3 +33,4 @@ url {
   ]
 }
 x-commit-hash: "d9ea0ab93da68f0d13ed710cc16f80983923f9ba"
+install: ["dune" "install" "-x" "windows" "-p" "lwt_ssl"]

--- a/packages/macaddr-windows/macaddr-windows.5.6.0/opam
+++ b/packages/macaddr-windows/macaddr-windows.5.6.0/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "macaddr" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
 description: """
@@ -35,3 +36,4 @@ url {
 }
 x-commit-hash: "a3852099627a9f9c56d75efe1c1adf4941c6c3d4"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "macaddr"]

--- a/packages/mad-windows/mad-windows.0.5.0/opam
+++ b/packages/mad-windows/mad-windows.0.5.0/opam
@@ -16,17 +16,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "mad"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "mad" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mad.git"
 depexts: [
@@ -42,3 +33,4 @@ url {
     "sha512=284e2be07f73d5d26378341194c34c28498aceb26d26dd3fd685016e19baba59943c8b4df08eb4be715430a92265a856cd594209ee9d7aed5d10b29b63857dff"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mad"]

--- a/packages/mad-windows/mad-windows.0.5.1/opam
+++ b/packages/mad-windows/mad-windows.0.5.1/opam
@@ -15,17 +15,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "mad"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "mad" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["libmad"] {os-distribution = "mxe"}
@@ -44,3 +35,4 @@ url {
     "sha512=98893912c62f37ff30a84ce9f06426781bdc22781eb7971be7ec32f46ed5a8b33b2474fc3c2dfb1afcacee9be7391fb7347a5be25b473b67abb994a66faca6d8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mad"]

--- a/packages/magic-mime-windows/magic-mime-windows.1.1.0/opam
+++ b/packages/magic-mime-windows/magic-mime-windows.1.1.0/opam
@@ -6,10 +6,10 @@ bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
 doc: "https://mirage.github.io/ocaml-magic-mime"
 license: "ISC"
-build: [[
-  "dune" "build"
-                      "-x" "windows"
-                     "-p" "magic-mime" "-j" jobs ]]
+build: [
+  ["dune" "build" "-x" "windows" "-p" "magic-mime" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0+beta9"}
@@ -41,3 +41,4 @@ url {
     "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.0/magic-mime-1.1.0.tbz"
   checksum: "md5=341ab5133c2e17ca645f23a0149025d1"
 }
+install: ["dune" "install" "-x" "windows" "-p" "magic-mime"]

--- a/packages/magic-mime-windows/magic-mime-windows.1.3.1/opam
+++ b/packages/magic-mime-windows/magic-mime-windows.1.3.1/opam
@@ -28,6 +28,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "magic-mime" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -38,3 +39,4 @@ url {
   ]
 }
 x-commit-hash: "605338f0e3684425d99d853c15d5ea9a1478b5ee"
+install: ["dune" "install" "-x" "windows" "-p" "magic-mime"]

--- a/packages/markup-windows/markup-windows.0.8.2/opam
+++ b/packages/markup-windows/markup-windows.0.8.2/opam
@@ -25,8 +25,8 @@ depends: [
 
 build: [
   ["dune" "build" "-p" "markup" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 description: """
 Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
 a simple interface: they are functions that transform byte streams to parsing
@@ -53,3 +53,4 @@ url {
 }
 
 
+install: ["dune" "install" "-x" "windows" "-p" "markup"]

--- a/packages/mem_usage-windows/mem_usage-windows.0.0.3/opam
+++ b/packages/mem_usage-windows/mem_usage-windows.0.0.3/opam
@@ -13,17 +13,8 @@ depends: [
 conflicts: ["base-domains"]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "mem_usage"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "mem_usage" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mem_usage.git"
 url {
@@ -33,3 +24,4 @@ url {
     "sha512=0d9b70da8965c0df70bfc8b50e476d10e2166ef09a7277bb012842317ecd995e9d21605983ecadd41b9b351582279ab4eef9f1388d623a5d6f000b928438c903"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mem_usage"]

--- a/packages/mem_usage-windows/mem_usage-windows.0.1.0/opam
+++ b/packages/mem_usage-windows/mem_usage-windows.0.1.0/opam
@@ -11,17 +11,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "mem_usage"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "mem_usage" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mem_usage.git"
 url {
@@ -32,3 +23,4 @@ url {
     "sha512=19a2772e0fdb55c6dd0cd01df2fba7ff8c8cf63dd3cd4361d4964464fe2acea664db75a0c97c5fd47b7b1a662cc23bdce61ae0d5298fcfc93b60a99d8ebab3a2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mem_usage"]

--- a/packages/mem_usage-windows/mem_usage-windows.0.1.1/opam
+++ b/packages/mem_usage-windows/mem_usage-windows.0.1.1/opam
@@ -12,17 +12,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "mem_usage"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "mem_usage" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mem_usage.git"
 url {
@@ -33,3 +24,4 @@ url {
     "sha512=4453ad7b409f1db08103abf458c28f8714d8c7c432c4b1be6d31edb7c463185b3087af358fa25eaae1a8808d9c684e893040f3ab7d82ce686c2bbeac333e68c0"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mem_usage"]

--- a/packages/memtrace-windows/memtrace-windows.0.2.2/opam
+++ b/packages/memtrace-windows/memtrace-windows.0.2.2/opam
@@ -11,17 +11,8 @@ depends: [
   "ocaml-windows" {>= "4.11.0" & < "5.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "memtrace"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "memtrace" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 post-messages: [
   "Tracing the current process is not supported on multicore ocaml, so uses of Gc.Memprof will fail. The library is still useful for reading and writing trace files even when Gc.Memprof is not working."
@@ -37,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "2045c8fae65fa52fdb0ba1b50e73364ed04e6c8d"
+install: ["dune" "install" "-x" "windows" "-p" "memtrace"]

--- a/packages/menhir-windows/menhir-windows.20210929/opam
+++ b/packages/menhir-windows/menhir-windows.20210929/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhir" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.02.3"}
@@ -28,3 +29,4 @@ url {
     "sha512=6a3cb084d1b2868022b4cb94484801aa7eaea13cfe2788b0da4407693229a6ce699cb282d9fd972476cf29551c259daa40f355dcdc1e545e47573a458a84c9dd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhir"]

--- a/packages/menhir-windows/menhir-windows.20230608/opam
+++ b/packages/menhir-windows/menhir-windows.20230608/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "GPL-2.0-only"
 build: [
   ["dune" "build" "-p" "menhir" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.03.0"}
@@ -28,3 +29,4 @@ url {
     "sha512=334b9dcb1283a28b8547082a89536b1d439ff588290b8eaecdf4802c5f74dbc8d16ad6fc6c0820036183518d83e2cc273a75787a8b41137424c8e7ee82e2b50a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhir"]

--- a/packages/menhir-windows/menhir-windows.20240715/opam
+++ b/packages/menhir-windows/menhir-windows.20240715/opam
@@ -11,6 +11,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "GPL-2.0-only"
 build: [
   ["dune" "build" "-p" "menhir" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.03.0"}
@@ -31,3 +32,4 @@ url {
     "sha512=4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhir"]

--- a/packages/menhirCST-windows/menhirCST-windows.20240715/opam
+++ b/packages/menhirCST-windows/menhirCST-windows.20240715/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirCST" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.08" }
@@ -27,3 +28,4 @@ url {
     "sha512=4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirCST"]

--- a/packages/menhirLib-windows/menhirLib-windows.20210929/opam
+++ b/packages/menhirLib-windows/menhirLib-windows.20210929/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirLib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.02.3" }
@@ -27,3 +28,4 @@ url {
     "sha512=6a3cb084d1b2868022b4cb94484801aa7eaea13cfe2788b0da4407693229a6ce699cb282d9fd972476cf29551c259daa40f355dcdc1e545e47573a458a84c9dd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirLib"]

--- a/packages/menhirLib-windows/menhirLib-windows.20230608/opam
+++ b/packages/menhirLib-windows/menhirLib-windows.20230608/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirLib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.03.0" }
@@ -27,3 +28,4 @@ url {
     "sha512=334b9dcb1283a28b8547082a89536b1d439ff588290b8eaecdf4802c5f74dbc8d16ad6fc6c0820036183518d83e2cc273a75787a8b41137424c8e7ee82e2b50a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirLib"]

--- a/packages/menhirLib-windows/menhirLib-windows.20240715/opam
+++ b/packages/menhirLib-windows/menhirLib-windows.20240715/opam
@@ -11,6 +11,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirLib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.03.0" }
@@ -28,3 +29,4 @@ url {
     "sha512=4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirLib"]

--- a/packages/menhirSdk-windows/menhirSdk-windows.20210929/opam
+++ b/packages/menhirSdk-windows/menhirSdk-windows.20210929/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirSdk" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.02.3" }
@@ -27,3 +28,4 @@ url {
     "sha512=6a3cb084d1b2868022b4cb94484801aa7eaea13cfe2788b0da4407693229a6ce699cb282d9fd972476cf29551c259daa40f355dcdc1e545e47573a458a84c9dd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirSdk"]

--- a/packages/menhirSdk-windows/menhirSdk-windows.20230608/opam
+++ b/packages/menhirSdk-windows/menhirSdk-windows.20230608/opam
@@ -10,6 +10,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirSdk" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.03.0" }
@@ -27,3 +28,4 @@ url {
     "sha512=334b9dcb1283a28b8547082a89536b1d439ff588290b8eaecdf4802c5f74dbc8d16ad6fc6c0820036183518d83e2cc273a75787a8b41137424c8e7ee82e2b50a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirSdk"]

--- a/packages/menhirSdk-windows/menhirSdk-windows.20240715/opam
+++ b/packages/menhirSdk-windows/menhirSdk-windows.20240715/opam
@@ -11,6 +11,7 @@ bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" "menhirSdk" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  { >= "4.03.0" }
@@ -28,3 +29,4 @@ url {
     "sha512=4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "menhirSdk"]

--- a/packages/metadata-windows/metadata-windows.0.2.0/opam
+++ b/packages/metadata-windows/metadata-windows.0.2.0/opam
@@ -12,17 +12,8 @@ depends: [
   "ocaml-windows" {>= "4.14.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "metadata"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "metadata" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-metadata.git"
 url {
@@ -33,3 +24,4 @@ url {
     "sha512=551177bf59767bdce327aab5ee16d5785f150e6e31f7399933fc4779b47bd4739c9eeec83320851a55165364083e48c4556896f7d9f21578ef1ef92cab886724"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "metadata"]

--- a/packages/metadata-windows/metadata-windows.0.3.0/opam
+++ b/packages/metadata-windows/metadata-windows.0.3.0/opam
@@ -12,17 +12,8 @@ depends: [
   "ocaml-windows" {>= "4.14.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "metadata"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "metadata" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-metadata.git"
 url {
@@ -33,3 +24,4 @@ url {
     "sha512=3e94f136f910d3484e688dd0afb3510a5b5d9618b2d991635416a69316e19653022ea21a236705be965a2980d1dc07370a115fd942b64e9d307103dbe02172ce"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "metadata"]

--- a/packages/mirage-crypto-ec-windows/mirage-crypto-ec-windows.2.0.0/opam
+++ b/packages/mirage-crypto-ec-windows/mirage-crypto-ec-windows.2.0.0/opam
@@ -35,6 +35,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "mirage-crypto-ec" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
 tags: ["org:mirage"]
@@ -48,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "cadf0e1230cada9f108e63321b30af24642e2b74"
+install: ["dune" "install" "-x" "windows" "-p" "mirage-crypto-ec"]

--- a/packages/mirage-crypto-pk-windows/mirage-crypto-pk-windows.2.0.0/opam
+++ b/packages/mirage-crypto-pk-windows/mirage-crypto-pk-windows.2.0.0/opam
@@ -8,8 +8,17 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "Simple public-key cryptography for the modern age"
 
-build: ["dune" "build" "-p" "mirage-crypto-pk" "-x" "windows" "-j" jobs ]
-
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "mirage-crypto-pk"
+  "-x"
+  "windows"
+  "-j"
+  jobs]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows" {>= "4.13.0"}
   "dune" {>= "2.7"}
@@ -32,3 +41,4 @@ url {
   ]
 }
 x-commit-hash: "cadf0e1230cada9f108e63321b30af24642e2b74"
+install: ["dune" "install" "-x" "windows" "-p" "mirage-crypto-pk"]

--- a/packages/mirage-crypto-rng-windows/mirage-crypto-rng-windows.2.0.0/opam
+++ b/packages/mirage-crypto-rng-windows/mirage-crypto-rng-windows.2.0.0/opam
@@ -8,8 +8,10 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "A cryptographically secure PRNG"
 
-build: [ ["dune" "build" "-p" "mirage-crypto-rng" "-x" "windows" "-j" jobs ] ]
-
+build: [
+  ["dune" "build" "-p" "mirage-crypto-rng" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows" {>= "4.14.0"}
   "dune" {>= "2.7"}
@@ -34,3 +36,4 @@ url {
   ]
 }
 x-commit-hash: "cadf0e1230cada9f108e63321b30af24642e2b74"
+install: ["dune" "install" "-x" "windows" "-p" "mirage-crypto-rng"]

--- a/packages/mirage-crypto-windows/mirage-crypto-windows.2.0.0/opam
+++ b/packages/mirage-crypto-windows/mirage-crypto-windows.2.0.0/opam
@@ -8,8 +8,10 @@ maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
 synopsis:     "Simple symmetric cryptography for the modern age"
 
-build: [ ["dune" "build" "-p" "mirage-crypto" "-x" "windows" "-j" jobs ] ]
-
+build: [
+  ["dune" "build" "-p" "mirage-crypto" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows" {>= "4.13.0"}
   "dune" {>= "2.7"}
@@ -32,3 +34,4 @@ url {
   ]
 }
 x-commit-hash: "cadf0e1230cada9f108e63321b30af24642e2b74"
+install: ["dune" "install" "-x" "windows" "-p" "mirage-crypto"]

--- a/packages/mm-windows/mm-windows.0.7.2/opam
+++ b/packages/mm-windows/mm-windows.0.7.2/opam
@@ -31,6 +31,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 depexts: [
@@ -43,3 +44,4 @@ url {
     "sha512=a8bffa9cd9b1b42c05c6d6af11648162d4189afe2a36a93883e08d7260f6cbe7fa6f3ca6582434eb9a20746a7004684474516990127bad017e12f2c7e4abeb53"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mm-windows/mm-windows.0.7.3/opam
+++ b/packages/mm-windows/mm-windows.0.7.3/opam
@@ -31,6 +31,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 depexts: [
@@ -43,3 +44,4 @@ url {
     "sha512=7760190cdf17d8e914b3c0b9e4eb3207cdc3f0f75c98a9a6dcb687935298b5eb3ca2a1c821513ce2f003b6865eef5fd7f2b375e44a2b6ce3abf01bae4725de09"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mm-windows/mm-windows.0.7.4/opam
+++ b/packages/mm-windows/mm-windows.0.7.4/opam
@@ -19,17 +19,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "mm"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "mm" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 depexts: [
@@ -42,3 +33,4 @@ url {
     "sha512=14eae4f480fa6b2f94811059c4811f0b967de32819b6908e0f3c03579f912614cad7351c12eb31c485b25a8dd4e86091853f93890a491a74c91a5b12e98ff28d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mm-windows/mm-windows.0.8.0/opam
+++ b/packages/mm-windows/mm-windows.0.8.0/opam
@@ -18,17 +18,8 @@ conflicts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "mm"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "mm" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=ff76e514726a6b0abeb043d374615d69b01ba212f06fb10de17aff2f161c447429460e3ac682364b9c0a1f00161648c696caaf596fc4a89cb95c6a33b143cdaa"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mm-windows/mm-windows.0.8.1/opam
+++ b/packages/mm-windows/mm-windows.0.8.1/opam
@@ -18,17 +18,8 @@ conflicts: [
   "alsa-windows" {< "0.3.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "mm"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "mm" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 depexts: [
@@ -41,3 +32,4 @@ url {
     "sha512=de153182cd51a52e55e7df6bf4abf46a19d7ebfc81dc13c6715a7f6321f77b8b321ee80343db9e84fdf7d0ea08d31c16fe0f646ad770937e884da7500a8e65e5"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mm-windows/mm-windows.0.8.4/opam
+++ b/packages/mm-windows/mm-windows.0.8.4/opam
@@ -18,17 +18,8 @@ conflicts: [
   "alsa-windows" {< "0.3.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "mm"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "mm" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=489e082866fd7db77248cb7e3a5d0a7e5af6c3390c9b27b317cce9bb3a48f26e6a05d1d55a662a181b5dcbeeec59aded5d0f08bd33c0ee8554655c5cad69a782"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mm-windows/mm-windows.0.8.6/opam
+++ b/packages/mm-windows/mm-windows.0.8.6/opam
@@ -18,17 +18,8 @@ conflicts: [
   "alsa-windows" {< "0.3.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "mm"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "mm" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-mm.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=c486e8eaa5dd25a2629c9486c4048ffa2cdeae9e56f73bc8d01a86413038dd3473ebd383abb06f08a2a24a78a335f22aede98ac92436e42a9c6eb1a856f92dab"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "mm"]

--- a/packages/mmap-windows/mmap-windows.1.1.0/opam
+++ b/packages/mmap-windows/mmap-windows.1.1.0/opam
@@ -8,6 +8,7 @@ dev-repo: "git+https://github.com/mirage/mmap.git"
 license: "LGPL 2.1 with linking exception"
 build: [
   ["dune" "build" "-x" "windows" "-p" "mmap" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"
@@ -22,3 +23,4 @@ url {
     "https://github.com/mirage/mmap/releases/download/v1.1.0/mmap-v1.1.0.tbz"
   checksum: "md5=8c5d5fbc537296dc525867535fb878ba"
 }
+install: ["dune" "install" "-x" "windows" "-p" "mmap"]

--- a/packages/multicore-magic-windows/multicore-magic-windows.2.3.0/opam
+++ b/packages/multicore-magic-windows/multicore-magic-windows.2.3.0/opam
@@ -10,17 +10,8 @@ depends: [
   "ocaml-windows" {>= "4.12.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "multicore-magic"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "multicore-magic" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/multicore-magic.git"
 url {
@@ -32,3 +23,4 @@ url {
   ]
 }
 x-commit-hash: "360c2e829c9addeca9ccaee1c71f4ad36bb14a79"
+install: ["dune" "install" "-x" "windows" "-p" "multicore-magic"]

--- a/packages/mustache-windows/mustache-windows.3.1.0/opam
+++ b/packages/mustache-windows/mustache-windows.3.1.0/opam
@@ -16,6 +16,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "mustache" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/rgrinberg/ocaml-mustache.git"
 synopsis: "Mustache logic-less templates in OCaml"
@@ -27,3 +28,4 @@ url {
   src: "https://github.com/rgrinberg/ocaml-mustache/archive/v3.1.0.zip"
   checksum: "md5=ee15623d0f699b6aff31904fedf4945e"
 }
+install: ["dune" "install" "-x" "windows" "-p" "mustache"]

--- a/packages/num-windows/num-windows.1.5/opam
+++ b/packages/num-windows/num-windows.1.5/opam
@@ -10,17 +10,8 @@ homepage: "https://github.com/ocaml/num/"
 bug-reports: "https://github.com/ocaml/num/issues"
 dev-repo: "git+https://github.com/ocaml/num.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "num"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "num" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.06.0" & < "5.4"}
@@ -36,3 +27,4 @@ url {
     "sha512=110dd01140c1c96f5f067aa824bb63f74a26411dcaa65aaf04cb6c44b116ca02aaab9505f431c66964388ce4a31d86da5928b4c0e5557800e834de80bed46495"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "num"]

--- a/packages/num-windows/num-windows.1.6/opam
+++ b/packages/num-windows/num-windows.1.6/opam
@@ -11,17 +11,8 @@ homepage: "https://github.com/ocaml/num/"
 bug-reports: "https://github.com/ocaml/num/issues"
 dev-repo: "git+https://github.com/ocaml/num.git"
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "num"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "num" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.06.0"}
@@ -38,3 +29,4 @@ url {
     "sha512=5cb32dfa9a9f0ad375bfd89079e9b1422979f3c089f61ef2300ad9cc64fb1fc25ed1f86b0267eb017f12ae41a574a959df5bfa39ab22c2be2f1ac84c3c671bdf"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "num"]

--- a/packages/ocaml-compiler-libs-windows/ocaml-compiler-libs-windows.v0.12.0/opam
+++ b/packages/ocaml-compiler-libs-windows/ocaml-compiler-libs-windows.v0.12.0/opam
@@ -7,6 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
 license: "Apache-2.0"
 build: [
   ["dune" "build" "-p" "ocaml-compiler-libs" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.1"}
@@ -21,3 +22,4 @@ url {
     "https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.0.tar.gz"
   checksum: "md5=3351925ed99be59829641d2044fc80c0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-compiler-libs"]

--- a/packages/ocaml-compiler-libs-windows/ocaml-compiler-libs-windows.v0.17.0/opam
+++ b/packages/ocaml-compiler-libs-windows/ocaml-compiler-libs-windows.v0.17.0/opam
@@ -7,6 +7,7 @@ dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ocaml-compiler-libs" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.2.0"}
@@ -26,3 +27,4 @@ url {
     "sha512=c5cd418b0eb74e00c3f63235754bbdb3a3328ac743d6ae885424d8c50b4edaa7068572e689cb3456d222793283927f2984a1ff840b1bc3817f810b5314faf897"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-compiler-libs"]

--- a/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.1.3.1/opam
+++ b/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.1.3.1/opam
@@ -12,6 +12,7 @@ doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
 tags: [ "syntax" "org:ocamllabs" ]
 build: [
   ["dune" "build" "-p" "ocaml-migrate-parsetree" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "result-windows"
@@ -36,3 +37,4 @@ url {
     "sha512=7da86f9596dd1439990a6f087fdeba64a0f3ce2634473be4cca92ecc02b6fcd97917956890fbe35b3cba5a126d007afec6ede1e4afd0a5218c89fd6079ad4182"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-migrate-parsetree"]

--- a/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.1.7.3/opam
+++ b/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.1.7.3/opam
@@ -12,6 +12,7 @@ doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
 tags: [ "syntax" "org:ocamllabs" ]
 build: [
   ["dune" "build" "-p" "ocaml-migrate-parsetree" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "result-windows"
@@ -36,3 +37,4 @@ url {
     "sha512=fe9c74a244d160d973d8ca62e356edad4c872fc46471ddc668f854456d3979576895d446d49da2aee61c65b441b72c573225b0b254ab2eac4a0fb4debdbce9d4"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-migrate-parsetree"]

--- a/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.1.8.0/opam
+++ b/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.1.8.0/opam
@@ -12,6 +12,7 @@ doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
 tags: [ "syntax" "org:ocamllabs" ]
 build: [
   ["dune" "build" "-p" "ocaml-migrate-parsetree" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "result-windows"
@@ -37,3 +38,4 @@ url {
     "sha512=c14ffacbba9fda34243b3e8310ce49414415b530bbd982eaa6c1891517c5a9a6a35887afa7d6f15f7f94e225a7f15cc25417fd3337e685d4a7d6ee160e50e66e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-migrate-parsetree"]

--- a/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.2.2.0/opam
+++ b/packages/ocaml-migrate-parsetree-windows/ocaml-migrate-parsetree-windows.2.2.0/opam
@@ -12,6 +12,7 @@ doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
 tags: [ "syntax" "org:ocamllabs" ]
 build: [
   ["dune" "build" "-p" "ocaml-migrate-parsetree" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {>= "2.3"}
@@ -37,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "aeeb9317936937d360aa6cdb0cab953d11ff2c5d"
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-migrate-parsetree"]

--- a/packages/ocaml-monadic-windows/ocaml-monadic-windows.0.4.1/opam
+++ b/packages/ocaml-monadic-windows/ocaml-monadic-windows.0.4.1/opam
@@ -12,7 +12,17 @@ depends: [
   "ppx_tools_versioned"
   "ocaml-windows" {>= "4.04.0"}
 ]
-build: ["dune" "build" "-p" "ocaml-monadic" "-x" "windows" "-j" jobs]
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "ocaml-monadic"
+  "-x"
+  "windows"
+  "-j"
+  jobs]
+  ["rm" "%{name}%.install"]
+]
 dev-repo: "git+https://github.com/zepalmer/ocaml-monadic.git"
 url {
   src:
@@ -22,3 +32,4 @@ url {
     "sha512=35d16c6d7671fecbb698e9ef6a71bac25afc99293f90a070a4a044f4c939f95a9ebcf4c24ff64b4ebfa7c7aa9f3d5bad2b27c0617b23aa18f41912df9607cfec"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml-monadic"]

--- a/packages/ocaml_intrinsics_kernel-windows/ocaml_intrinsics_kernel-windows.v0.17.1/opam
+++ b/packages/ocaml_intrinsics_kernel-windows/ocaml_intrinsics_kernel-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics_kernel
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ocaml_intrinsics_kernel" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
     "sha512=21e596d6407a620866cee7cab47ef1a9446d6a733b4994e809ea5566d5fa956682a5c6a6190ffb0ed48458abd658301944ed10c4389d91ecb8df677a5f87f2ab"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocaml_intrinsics_kernel"]

--- a/packages/ocplib-endian-windows/ocplib-endian-windows.1.2/opam
+++ b/packages/ocplib-endian-windows/ocplib-endian-windows.1.2/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.0"}
 ]
 build: [
-  "dune"
+  ["dune"
   "build"
   "-p"
   "ocplib-endian"
@@ -27,7 +27,8 @@ build: [
   "windows"
   "-j"
   jobs
-  "@install"
+  "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/OCamlPro/ocplib-endian.git"
 url {
@@ -38,3 +39,4 @@ url {
     "sha512=2e70be5f3d6e377485c60664a0e235c3b9b24a8d6b6a03895d092c6e40d53810bfe1f292ee69e5181ce6daa8a582bfe3d59f3af889f417134f658812be5b8b85"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ocplib-endian"]

--- a/packages/octavius-windows/octavius-windows.1.2.0/opam
+++ b/packages/octavius-windows/octavius-windows.1.2.0/opam
@@ -17,7 +17,8 @@ depends: [
 ]
 build: [
   ["dune" "subst" "-x" "windows"] {pinned}
-  ["dune" "build"  "-p" "octavius" "-j" jobs "-x" "windows"]
+  ["dune" "build" "-p" "octavius" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 synopsis: "Ocamldoc comment syntax parser"
 description: "Octavius is a library to parse the `ocamldoc` comment syntax."
@@ -25,3 +26,4 @@ url {
   src: "https://github.com/ocaml-doc/octavius/archive/v1.2.0.tar.gz"
   checksum: "md5=3e6049c39045354853d9dc3a197133ac"
 }
+install: ["dune" "install" "-x" "windows" "-p" "octavius"]

--- a/packages/octavius-windows/octavius-windows.1.2.2/opam
+++ b/packages/octavius-windows/octavius-windows.1.2.2/opam
@@ -11,17 +11,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {pinned}
-  [
-    "dune"
-    "build"
-    "-p"
-    "octavius"
-    "-j"
-    jobs
-    "@install"
-    "-x"
-    "windows"
-  ]
+  ["dune" "build" "-p" "octavius" "-j" jobs "@install" "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-doc/octavius.git"
 
@@ -31,3 +22,4 @@ url {
   src: "https://github.com/ocaml-doc/octavius/archive/v1.2.2.tar.gz"
   checksum: "md5=72f9e1d996e6c5089fc513cc9218607b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "octavius"]

--- a/packages/ogg-windows/ogg-windows.0.7.0/opam
+++ b/packages/ogg-windows/ogg-windows.0.7.0/opam
@@ -12,17 +12,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ogg"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ogg" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ogg"] {os-distribution = "mxe"}
@@ -35,3 +26,4 @@ url {
     "sha512=fdf7a474ed8fa3748f46d5b8e07fdd2d0a11774a7b48b02276f105c188db30fe6278f5858947259b9a468489c53addb272bfc9c17816b7a9e0848e12793aa623"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ogg"]

--- a/packages/ogg-windows/ogg-windows.0.7.2/opam
+++ b/packages/ogg-windows/ogg-windows.0.7.2/opam
@@ -12,17 +12,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ogg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ogg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ogg"] {os-distribution = "mxe"}
@@ -35,3 +26,4 @@ url {
     "sha512=92c7bef22ef17e129aef273dd53e122115f27a640b486b1a201c99005c435757669f3a363d05c8d79d4c28b2ac6833ae8c3891e57593de74a9535f6adc7f6f0e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ogg"]

--- a/packages/ogg-windows/ogg-windows.0.7.4/opam
+++ b/packages/ogg-windows/ogg-windows.0.7.4/opam
@@ -12,17 +12,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ogg"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ogg" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["ogg"] {os-distribution = "mxe"}
@@ -35,3 +26,4 @@ url {
     "sha512=5f23ee730d234a89e9b402e83fd2185f65b4cb9612b3f0f15f267baf43f45c28fe9273a57fc8d7d3882fb7817ad628b3f3c847cfe989594190b9e5150a9ab3a2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ogg"]

--- a/packages/ohex-windows/ohex-windows.0.2.0/opam
+++ b/packages/ohex-windows/ohex-windows.0.2.0/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "ohex" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://git.robur.coop/robur/ohex.git"
 url {
@@ -23,3 +24,4 @@ url {
   ]
 }
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "ohex"]

--- a/packages/optint-windows/optint-windows.0.0.4/opam
+++ b/packages/optint-windows/optint-windows.0.0.4/opam
@@ -15,8 +15,17 @@ On x86, this library use a boxed int32.
 Implementation depends on target architecture.
 """
 
-build: ["dune" "build" "-p" "optint" "-j" jobs "-x" "windows"]
-
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "optint"
+  "-j"
+  jobs
+  "-x"
+  "windows"]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows"
   "dune"
@@ -29,3 +38,4 @@ url {
     "sha512=6127f5d216a66a376b75a309627e2c52c08d655c4a88a2d1df2b622d98abfe011fb10175f5f99737e950c8095596ef8fd680fe2338f53383e2263edb2d3a5c49"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "optint"]

--- a/packages/opus-windows/opus-windows.0.2.1/opam
+++ b/packages/opus-windows/opus-windows.0.2.1/opam
@@ -27,6 +27,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["opus"] {os-distribution = "mxe"}
@@ -39,3 +40,4 @@ url {
     "sha512=4c1f4ecbdad31e140ee512d95bdf74f8ff64260575a5202f8a013fe1b2768f34911eea6e7e029600ce028e0245e46bf227af3407e28e120feafa121f5ef3e686"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "opus"]

--- a/packages/opus-windows/opus-windows.0.2.2/opam
+++ b/packages/opus-windows/opus-windows.0.2.2/opam
@@ -12,17 +12,8 @@ depends: [
   "ogg-windows" {>= "0.7.1"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "opus"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "opus" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["opus"] {os-distribution = "mxe"}
@@ -35,3 +26,4 @@ url {
     "sha512=e9931a80550ed3566cebc4e07204192319fdb02c88519f6711c57ec2cb8d68e13f641bd843c815244010e4be8fbada95d826063e33297113a5c3743c3a4e2a5d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "opus"]

--- a/packages/ordering-windows/ordering-windows.3.19.1/opam
+++ b/packages/ordering-windows/ordering-windows.3.19.1/opam
@@ -16,17 +16,8 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["rm" "-rf" "vendor/csexp"]
   ["rm" "-rf" "vendor/pp"]
-  [
-    "dune"
-    "build"
-    "-p"
-    "ordering"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ordering" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -37,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "ordering"]

--- a/packages/parsexp-windows/parsexp-windows.v0.12.0/opam
+++ b/packages/parsexp-windows/parsexp-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "parsexp" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -42,3 +43,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/parsexp-v0.12.0.tar.gz"
   checksum: "md5=741b2c6f59b9618e3affabaa34d468a2"
 }
+install: ["dune" "install" "-x" "windows" "-p" "parsexp"]

--- a/packages/parsexp-windows/parsexp-windows.v0.14.0/opam
+++ b/packages/parsexp-windows/parsexp-windows.v0.14.0/opam
@@ -11,6 +11,7 @@ patches: [
 ]
 build: [
   ["dune" "build" "-p" "parsexp" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -50,3 +51,4 @@ url {
   src: "https://github.com/janestreet/parsexp/archive/refs/tags/v0.14.1.tar.gz"
   checksum: "e6659d53f4d94de8979e05d17222b753"
 }
+install: ["dune" "install" "-x" "windows" "-p" "parsexp"]

--- a/packages/parsexp-windows/parsexp-windows.v0.16.0/opam
+++ b/packages/parsexp-windows/parsexp-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "parsexp" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -40,3 +41,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/parsexp-v0.16.0.tar.gz"
 checksum: "sha256=b6e2572c8e6191a85cb8f9c3276ed87fe00522c81ba7a268179fb08185e55e12"
 }
+install: ["dune" "install" "-x" "windows" "-p" "parsexp"]

--- a/packages/parsexp-windows/parsexp-windows.v0.17.0/opam
+++ b/packages/parsexp-windows/parsexp-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "parsexp" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -41,3 +42,4 @@ url {
 src: "https://github.com/janestreet/parsexp/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=a3d10edbc4f98d16357b644d550fd1c06f4d9aa4990ab8ee6da01276c24d55b5"
 }
+install: ["dune" "install" "-x" "windows" "-p" "parsexp"]

--- a/packages/pcre-windows/pcre-windows.7.3.4/opam
+++ b/packages/pcre-windows/pcre-windows.7.3.4/opam
@@ -8,11 +8,21 @@ dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
 bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 
 build: [
-  ["dune" "subst"]{pinned}
-  ["env" "PKG_CONFIG_PATH=%{conf-gcc-windows:c-lib}%/pkgconfig" 
-   "dune" "build"  "-p" "pcre" "-j" jobs "-x" "windows"]
+  ["dune" "subst"] {pinned}
+  [
+    "env"
+    "PKG_CONFIG_PATH=%{conf-gcc-windows:c-lib}%/pkgconfig"
+    "dune"
+    "build"
+    "-p"
+    "pcre"
+    "-j"
+    jobs
+    "-x"
+    "windows"
+  ]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml" {>= "4.04"}
   "base-windows" {build}
@@ -34,3 +44,4 @@ url {
 depexts: [
   ["pcre"] {os-distribution = "mxe"}
 ]
+install: ["dune" "install" "-x" "windows" "-p" "pcre"]

--- a/packages/pcre-windows/pcre-windows.7.4.1/opam
+++ b/packages/pcre-windows/pcre-windows.7.4.1/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/mmottl/pcre-ocaml/issues"
 
 build: [
   ["dune" "build" "-p" "pcre" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.04"}
   "dune"          {build & >= "1.4.0"}
@@ -31,3 +31,4 @@ url {
 depexts: [
   ["pcre"] {os-distribution = "mxe"}
 ]
+install: ["dune" "install" "-x" "windows" "-p" "pcre"]

--- a/packages/pcre-windows/pcre-windows.7.4.3/opam
+++ b/packages/pcre-windows/pcre-windows.7.4.3/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "pcre" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
 authors: ["Markus Mottl <markus.mottl@gmail.com>"]
@@ -33,3 +34,4 @@ url {
     "sha512=917e98aa86a75d2e17b0df9eb546c5dc568eacd0f2df0c5621467246142beff449e11544d88bc42eabf1cc288f7aa19aaebe90283ca8cf72dc023e52c6c21e02"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "pcre"]

--- a/packages/pcre-windows/pcre-windows.7.4.6/opam
+++ b/packages/pcre-windows/pcre-windows.7.4.6/opam
@@ -3,6 +3,7 @@ build: [
   ["dune" "build" "-p" "pcre" "-j" jobs "-x" "windows"]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "-p" name "@doc"] {with-doc}
+  ["rm" "%{name}%.install"]
 ]
 maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
 authors: ["Markus Mottl <markus.mottl@gmail.com>"]
@@ -33,3 +34,4 @@ url {
     "sha512=a356c78dc19d3b3741d1fa0277c4fb0cb545f12499165526fae80a0ff8a7b1f1e6e5e916b16f8336bcec3661de811686b814fe4afc677965fec7a63d4fc53b1f"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "pcre"]

--- a/packages/pcre-windows/pcre-windows.7.5.0/opam
+++ b/packages/pcre-windows/pcre-windows.7.5.0/opam
@@ -19,17 +19,8 @@ build-env: [
   [PKG_CONFIG = "%{conf-gcc-windows64:prefix}%pkg-config"]
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "pcre"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "pcre" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["pcre"] {os-distribution = "mxe"}
@@ -43,3 +34,4 @@ url {
     "sha512=be60f13ddb6bbfe20e30ca5d92434d85e1d1371479e1e2c725588af83fcc9366ed0435021b6a800c20336ac521f2134c767420136438684656a44ac1f9924be4"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "pcre"]

--- a/packages/poll-windows/poll-windows.0.3.1/opam
+++ b/packages/poll-windows/poll-windows.0.3.1/opam
@@ -20,17 +20,8 @@ depends: [
   "ocaml-windows" {>= "4.13"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "poll"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "poll" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/anuragsoni/poll.git"
 conflicts: [
@@ -46,3 +37,4 @@ url {
   ]
 }
 x-commit-hash: "303cd7b5254b6a7f1557507651d9ae34eecf8f14"
+install: ["dune" "install" "-x" "windows" "-p" "poll"]

--- a/packages/portaudio-windows/portaudio-windows.0.2.3/opam
+++ b/packages/portaudio-windows/portaudio-windows.0.2.3/opam
@@ -15,17 +15,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "portaudio"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "portaudio" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["portaudio"] {os-distribution = "mxe"}
@@ -38,3 +29,4 @@ url {
     "sha512=9f292e7e9dc073472488eff97e28ddc538a6f6f6fcfd2bbdc94d0fe7a40c94c0c30685c26df96eb7a9e1b6ceac933ec0fde6779322b8649adecd248ca4f41379"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "portaudio"]

--- a/packages/posix-base-windows/posix-base-windows.2.0.2/opam
+++ b/packages/posix-base-windows/posix-base-windows.2.0.2/opam
@@ -15,17 +15,8 @@ depends: [
   "ctypes-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-base"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-base" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
 url {
@@ -36,3 +27,4 @@ url {
     "sha512=6f5fa0fd5f3f0b845c2c9cd46a53e518dc5187f1ea7450fc04bbdc4c7b6fbcc427253e60847cc14f5bff895622e18aea404fbd8e14d4b50f52a7c0e682621ac8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "posix-base"]

--- a/packages/posix-base-windows/posix-base-windows.2.1.0/opam
+++ b/packages/posix-base-windows/posix-base-windows.2.1.0/opam
@@ -15,17 +15,8 @@ depends: [
   "ctypes-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-base"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-base" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
 url {
@@ -36,3 +27,4 @@ url {
     "sha512=735c6afd48e36af0a032f51217e7558629a198fd39a0484883831bdbff511b331033696b8ad73c6896fa9df0a0b1fd2f27336c2b0b7447dd10902e6bc64e4886"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "posix-base"]

--- a/packages/posix-base-windows/posix-base-windows.2.2.0/opam
+++ b/packages/posix-base-windows/posix-base-windows.2.2.0/opam
@@ -17,17 +17,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-base"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-base" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
 url {
@@ -38,3 +29,4 @@ url {
     "sha512=a0fae5a98b9ab63d5273d357292a74ac69c694bdd672b0cbd62b5beb5847e63c17fb0de0a1fb9f36b7bc9f10f7b990298ee63853d8399b9b8a9005c1c7b37ba3"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "posix-base"]

--- a/packages/posix-socket-windows/posix-socket-windows.2.0.2/opam
+++ b/packages/posix-socket-windows/posix-socket-windows.2.0.2/opam
@@ -17,17 +17,8 @@ depends: [
   "posix-base-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-socket"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-socket" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 patches: [
   "patches/fix-wine-call.patch"
@@ -44,3 +35,4 @@ url {
     "sha512=6f5fa0fd5f3f0b845c2c9cd46a53e518dc5187f1ea7450fc04bbdc4c7b6fbcc427253e60847cc14f5bff895622e18aea404fbd8e14d4b50f52a7c0e682621ac8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "posix-socket"]

--- a/packages/posix-socket-windows/posix-socket-windows.2.1.0/opam
+++ b/packages/posix-socket-windows/posix-socket-windows.2.1.0/opam
@@ -17,17 +17,8 @@ depends: [
   "posix-base-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-socket"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-socket" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
 url {
@@ -41,3 +32,4 @@ url {
 extra-files: [
   "patches/fix-wine-call.patch" "md5=3edda19e24f47830691d8931c8299b84"
 ]
+install: ["dune" "install" "-x" "windows" "-p" "posix-socket"]

--- a/packages/posix-socket-windows/posix-socket-windows.2.2.0/opam
+++ b/packages/posix-socket-windows/posix-socket-windows.2.2.0/opam
@@ -18,17 +18,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-socket"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-socket" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
 url {
@@ -39,3 +30,4 @@ url {
     "sha512=a0fae5a98b9ab63d5273d357292a74ac69c694bdd672b0cbd62b5beb5847e63c17fb0de0a1fb9f36b7bc9f10f7b990298ee63853d8399b9b8a9005c1c7b37ba3"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "posix-socket"]

--- a/packages/posix-socket-windows/posix-socket-windows.3.0.0/opam
+++ b/packages/posix-socket-windows/posix-socket-windows.3.0.0/opam
@@ -16,17 +16,8 @@ depends: [
   "posix-base-windows" {>= "2.2"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "posix-socket"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "posix-socket" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
 url {
@@ -37,3 +28,4 @@ url {
     "sha512=bfe8ff032d87abfc73df33662a5313a6eb8b78f8365523f7b68f9867868cfc5ad20c4d542c6db27cdb2544d209fa3dc658653fc20af9f2c92035e17b6d7c8982"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "posix-socket"]

--- a/packages/pp-windows/pp-windows.2.0.0/opam
+++ b/packages/pp-windows/pp-windows.2.0.0/opam
@@ -32,17 +32,8 @@ depends: [
   "ocaml-windows" {>= "4.08"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "pp"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "pp" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-dune/pp.git"
 url {
@@ -54,3 +45,4 @@ url {
   ]
 }
 x-commit-hash: "b6741dd41ef5fc5bda8b3640097ac29818a43577"
+install: ["dune" "install" "-x" "windows" "-p" "pp"]

--- a/packages/ppx_assert-windows/ppx_assert-windows.v0.14.0/opam
+++ b/packages/ppx_assert-windows/ppx_assert-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_assert/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_assert" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.04.2"}
@@ -32,3 +33,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_assert-v0.14.0.tar.gz"
   checksum: "md5=535b5f241eb7f10da8c044c26afbc186"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_assert"]

--- a/packages/ppx_assert-windows/ppx_assert-windows.v0.16.0/opam
+++ b/packages/ppx_assert-windows/ppx_assert-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_assert/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_assert" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.14.0"}
@@ -33,3 +34,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_assert-v0.16.0.tar.gz"
 checksum: "sha256=57dc6e241827eb1d5112c958f2f682ddd0addf5a8e9d589f5361ec2669883fd5"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_assert"]

--- a/packages/ppx_assert-windows/ppx_assert-windows.v0.17.0/opam
+++ b/packages/ppx_assert-windows/ppx_assert-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_assert/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_assert" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -34,3 +35,4 @@ url {
 src: "https://github.com/janestreet/ppx_assert/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=94c47289a6393642b1cca7d2cdb8decdbf387c3cee4faf50d9b00efc871cce8b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_assert"]

--- a/packages/ppx_base-windows/ppx_base-windows.v0.14.0/opam
+++ b/packages/ppx_base-windows/ppx_base-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_base" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.04.2"}
@@ -38,3 +39,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_base-v0.14.0.tar.gz"
   checksum: "md5=b29a24907e60f42e050ad90e5209bb92"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_base"]

--- a/packages/ppx_base-windows/ppx_base-windows.v0.15.0/opam
+++ b/packages/ppx_base-windows/ppx_base-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_base" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.08.0"}
@@ -36,3 +37,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/ppx_base-v0.15.0.tar.gz"
 checksum: "sha256=d6bbad352ea547c9c0a3636abe87287d5a680b46a06ddd70d6126905853f3ca0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_base"]

--- a/packages/ppx_base-windows/ppx_base-windows.v0.16.0/opam
+++ b/packages/ppx_base-windows/ppx_base-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_base" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.14.0"}
@@ -38,3 +39,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_base-v0.16.0.tar.gz"
 checksum: "sha256=64835763153d3262a2fa56cf307a351ebfd10cedf504c488ab3bb93f3d9569a3"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_base"]

--- a/packages/ppx_base-windows/ppx_base-windows.v0.17.0/opam
+++ b/packages/ppx_base-windows/ppx_base-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_base" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -42,3 +43,4 @@ url {
 src: "https://github.com/janestreet/ppx_base/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=80e7e6c6a704114d1d0989ee9bc01bca45278096c0caf3f2c4ef28d3c12ae61c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_base"]

--- a/packages/ppx_bench-windows/ppx_bench-windows.v0.14.1/opam
+++ b/packages/ppx_bench-windows/ppx_bench-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bench" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://github.com/janestreet/ppx_bench/archive/v0.14.1.tar.gz"
   checksum: "md5=f2852170a6396d60d4fc1c156be1ec62"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bench"]

--- a/packages/ppx_bench-windows/ppx_bench-windows.v0.16.0/opam
+++ b/packages/ppx_bench-windows/ppx_bench-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bench" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_bench-v0.16.0.tar.gz"
 checksum: "sha256=e307fc25b4cb38125685fa01888255d00aaf6c1b82f52c4f02ebd48a4471761d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bench"]

--- a/packages/ppx_bench-windows/ppx_bench-windows.v0.17.0/opam
+++ b/packages/ppx_bench-windows/ppx_bench-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bench" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/ppx_bench/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=7e91a1b7c82fc512560ca1de14deab3754dc2df4adc924112e68bede74691ba2"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bench"]

--- a/packages/ppx_bench-windows/ppx_bench-windows.v0.17.1/opam
+++ b/packages/ppx_bench-windows/ppx_bench-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bench" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "5.1.0"}
@@ -30,3 +31,4 @@ url {
     "sha512=7492c19b408709368f5a1ed020bea2c439ff562f765cd706637dbfb7ecdfc33478f9dd814fcf195292bf634769ae95f8b89b5b33b714e0fd6248f0754e1d37a4"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bench"]

--- a/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.14.0/opam
+++ b/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bin_prot" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -27,3 +28,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_bin_prot-v0.14.0.tar.gz"
   checksum: "md5=016e777c366b9b464f016d70ae4d7b7f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bin_prot"]

--- a/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.16.0/opam
+++ b/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bin_prot" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_bin_prot-v0.16.0.tar.gz"
 checksum: "sha256=94486e7d6357f12f8aa358196783822c500b3b2fe04c597ea86c1c42bc5c3b61"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bin_prot"]

--- a/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.17.0/opam
+++ b/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bin_prot" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
 src: "https://github.com/janestreet/ppx_bin_prot/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=64b242cdad8b0f9ce9c86153e8e8d3e74bef9aa507d5e481c920d9154d3ab505"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bin_prot"]

--- a/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.17.1/opam
+++ b/packages/ppx_bin_prot-windows/ppx_bin_prot-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_bin_prot" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -35,3 +36,4 @@ url {
     "sha512=b5fd4b5718a1486b3f6e5c3ae424a254e30776499ed1d64df7679b7d3f30c1155cfeff0abe29b1426a3b0b58a7bb1bb9fdfb04076bcd6be8ce093c882bae8bf7"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_bin_prot"]

--- a/packages/ppx_blob-windows/ppx_blob-windows.0.9.0/opam
+++ b/packages/ppx_blob-windows/ppx_blob-windows.0.9.0/opam
@@ -9,6 +9,7 @@ license: "Unlicense"
 build: [
   ["dune" "build" "-p" "ppx_blob" "-x" "windows" "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.08"}
@@ -29,3 +30,4 @@ url {
   ]
 }
 x-commit-hash: "38c7693141bd629b70cd8a17306f5ce359ea9c59"
+install: ["dune" "install" "-x" "windows" "-p" "ppx_blob"]

--- a/packages/ppx_cold-windows/ppx_cold-windows.v0.14.0/opam
+++ b/packages/ppx_cold-windows/ppx_cold-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_cold" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -26,3 +27,4 @@ url {
   checksum: "md5=6a61807cd3b105b8c885bd2076986339"
 }
 
+install: ["dune" "install" "-x" "windows" "-p" "ppx_cold"]

--- a/packages/ppx_cold-windows/ppx_cold-windows.v0.15.0/opam
+++ b/packages/ppx_cold-windows/ppx_cold-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_cold" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.08.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/ppx_cold-v0.15.0.tar.gz"
 checksum: "sha256=8b9fae3341332411e46209d6639d75810260caa897aff4945500612db8abf88d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_cold"]

--- a/packages/ppx_cold-windows/ppx_cold-windows.v0.16.0/opam
+++ b/packages/ppx_cold-windows/ppx_cold-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_cold" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_cold-v0.16.0.tar.gz"
 checksum: "sha256=803bdb583b501aa246d8ae34be0c16b892d8ae96852bb593f3e355232e6aa4da"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_cold"]

--- a/packages/ppx_cold-windows/ppx_cold-windows.v0.17.0/opam
+++ b/packages/ppx_cold-windows/ppx_cold-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_cold" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/ppx_cold/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=670ee6f4efef2020a4bedf91b72cc2cd97ea0d74b47dad2f8f6b72d722a7452d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_cold"]

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.12.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_compare" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -24,3 +25,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_compare-v0.12.0.tar.gz"
   checksum: "md5=e50fddd9fd7ece75ec8a861e7c1e7e18"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_compare"]

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.14.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_compare" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -24,3 +25,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_compare-v0.14.0.tar.gz"
   checksum: "md5=9149b3a0c954fe2cef2b0705d254b9e3"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_compare"]

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.15.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_compare" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.08.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/ppx_compare-v0.15.0.tar.gz"
 checksum: "sha256=6a0728929a7b591dffa0f1099d989854f871238697c70b34475eb9ffdce17385"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_compare"]

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.16.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_compare" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_compare-v0.16.0.tar.gz"
 checksum: "sha256=7ac1dd852e62de6c4b6a879b8bd962c0167db822c39e8c972c8a6af4c48f26aa"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_compare"]

--- a/packages/ppx_compare-windows/ppx_compare-windows.v0.17.0/opam
+++ b/packages/ppx_compare-windows/ppx_compare-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_compare" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_compare/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=f0b23eb78082ef4dc71a66939bbc63c6b0cc2cf6a4744a906b7a2c016cbe3098"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_compare"]

--- a/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.14.1/opam
+++ b/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_custom_printf/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_custom_printf" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.04.2"}
@@ -26,3 +27,4 @@ url {
   src: "https://github.com/janestreet/ppx_custom_printf/archive/v0.14.1.tar.gz"
   checksum: "md5=18518b0464d61d165f4c73475d648ccb"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_custom_printf"]

--- a/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.16.0/opam
+++ b/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_custom_printf/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_custom_printf" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.14.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_custom_printf-v0.16.0.tar.gz"
 checksum: "sha256=2161639b7b81712abf503098202e108b3cff3d652f0ee517908081308264a1a6"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_custom_printf"]

--- a/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.17.0/opam
+++ b/packages/ppx_custom_printf-windows/ppx_custom_printf-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_custom_printf/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_custom_printf" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_custom_printf/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=cd3cf73c31f6b0e18677ce92ce0e6f866b0596d5ea1fc540212c422930a730a0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_custom_printf"]

--- a/packages/ppx_derivers-windows/ppx_derivers-windows.1.0/opam
+++ b/packages/ppx_derivers-windows/ppx_derivers-windows.1.0/opam
@@ -6,7 +6,8 @@ homepage: "https://github.com/diml/ppx_derivers"
 bug-reports: "https://github.com/diml/ppx_derivers/issues"
 dev-repo: "git://github.com/diml/ppx_derivers.git"
 build: [
-  ["dune" "build"  "-p" "ppx_derivers" "-j" jobs "-x" "windows"]
+  ["dune" "build" "-p" "ppx_derivers" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml"
@@ -22,3 +23,4 @@ url {
   src: "https://github.com/diml/ppx_derivers/archive/1.0.tar.gz"
   checksum: "md5=4ddce8f43fdb9b0ef0ab6a7cbfebc3e3"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_derivers"]

--- a/packages/ppx_derivers-windows/ppx_derivers-windows.1.2.1/opam
+++ b/packages/ppx_derivers-windows/ppx_derivers-windows.1.2.1/opam
@@ -7,6 +7,7 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
 dev-repo: "git://github.com/ocaml-ppx/ppx_derivers.git"
 build: [
   ["dune" "build" "-p" "ppx_derivers" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"
@@ -21,3 +22,4 @@ url {
   src: "https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz"
   checksum: "md5=5dc2bf130c1db3c731fe0fffc5648b41"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_derivers"]

--- a/packages/ppx_deriving-windows/ppx_deriving-windows.5.2.1/opam
+++ b/packages/ppx_deriving-windows/ppx_deriving-windows.5.2.1/opam
@@ -10,6 +10,7 @@ tags: [ "syntax" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "ppx_deriving" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.05.0" & < "5.3"}
@@ -39,3 +40,4 @@ url {
   ]
 }
 x-commit-hash: "7211546d6527bf57d3eff8174c90fc3c22250dae"
+install: ["dune" "install" "-x" "windows" "-p" "ppx_deriving"]

--- a/packages/ppx_deriving-windows/ppx_deriving-windows.6.0.3/opam
+++ b/packages/ppx_deriving-windows/ppx_deriving-windows.6.0.3/opam
@@ -10,6 +10,7 @@ tags: [ "syntax" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "ppx_deriving" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.05.0"}
@@ -37,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "275140702ca6f97e0407f80e86de9d3940ee3ac8"
+install: ["dune" "install" "-x" "windows" "-p" "ppx_deriving"]

--- a/packages/ppx_deriving-windows/ppx_deriving-windows.6.1.1/opam
+++ b/packages/ppx_deriving-windows/ppx_deriving-windows.6.1.1/opam
@@ -25,6 +25,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "ppx_deriving" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
 url {
@@ -35,3 +36,4 @@ url {
     "sha512=9d64fd1a7c908e70ac11164db6732d69e74eac28c29ba6d76d40711554615c0af5a8c491eb6f05181b99294b50fc2c50b454b6d75d022db9d33133188d071102"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_deriving"]

--- a/packages/ppx_diff-windows/ppx_diff-windows.v0.17.0/opam
+++ b/packages/ppx_diff-windows/ppx_diff-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_diff/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_diff" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -36,3 +37,4 @@ url {
 src: "https://github.com/janestreet/ppx_diff/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=5e817094edf127d384110227ecfdc3e23f0f130266d48d1f326a03f6f58a2609"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_diff"]

--- a/packages/ppx_diff-windows/ppx_diff-windows.v0.17.1/opam
+++ b/packages/ppx_diff-windows/ppx_diff-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_diff/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_diff" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -40,3 +41,4 @@ url {
     "sha512=5848274cb0c5acd1ee3f29318e6111c5fef4b357aeda78120e0370067b9b23f62bb57e1e0be948c3af385b5900a3e0fb657f26dd4fe7ee95cd7002b9d8b68547"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_diff"]

--- a/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.16.0/opam
+++ b/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.16.0/opam
@@ -7,7 +7,10 @@ dev-repo: "git+https://github.com/janestreet/ppx_disable_unused_warnings.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_disable_unused_warnings/index.html"
 license: "MIT"
 build: [
-  ["dune" "build" "-p" "ppx_disable_unused_warnings" "-x" "windows" "-j" jobs]
+  [
+    "dune" "build" "-p" "ppx_disable_unused_warnings" "-x" "windows" "-j" jobs
+  ]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +28,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_disable_unused_warnings-v0.16.0.tar.gz"
 checksum: "sha256=3fd18ff840e4f84eb34683efdd56508ba330011b8f906d0f60684f8fce4298e7"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_disable_unused_warnings"]

--- a/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.17.0/opam
+++ b/packages/ppx_disable_unused_warnings-windows/ppx_disable_unused_warnings-windows.v0.17.0/opam
@@ -7,7 +7,10 @@ dev-repo: "git+https://github.com/janestreet/ppx_disable_unused_warnings.git"
 doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_disable_unused_warnings/index.html"
 license: "MIT"
 build: [
-  ["dune" "build" "-p" "ppx_disable_unused_warnings" "-x" "windows" "-j" jobs]
+  [
+    "dune" "build" "-p" "ppx_disable_unused_warnings" "-x" "windows" "-j" jobs
+  ]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -26,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_disable_unused_warnings/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=af5dfa6bb51aa90f5c322ab4920fb46583cffc9460f583439afb2ef851310fbf"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_disable_unused_warnings"]

--- a/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.14.0/opam
+++ b/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_enumerate" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -24,3 +25,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_enumerate-v0.14.0.tar.gz"
   checksum: "md5=188421af960759f6e45dd748f4f08e8d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_enumerate"]

--- a/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.15.0/opam
+++ b/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_enumerate" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml"  {>= "4.08.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/ppx_enumerate-v0.15.0.tar.gz"
 checksum: "sha256=deb5fb9ca12ade3e4fb8093f1cfdf50a03735b9db19a7535ad534331fb98d09b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_enumerate"]

--- a/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.16.0/opam
+++ b/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_enumerate" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_enumerate-v0.16.0.tar.gz"
 checksum: "sha256=2832635d6d9ac4c63d48ed51d72745cd8a548e226a6110909d5a412d40ef9953"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_enumerate"]

--- a/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.17.0/opam
+++ b/packages/ppx_enumerate-windows/ppx_enumerate-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_enumerate" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_enumerate/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=a27f1797b1315bdf7678fde783dff493bd348f1c5b644d7616b660bd295dad36"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_enumerate"]

--- a/packages/ppx_expect-windows/ppx_expect-windows.v0.14.1/opam
+++ b/packages/ppx_expect-windows/ppx_expect-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_expect" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "4.04.2"}
@@ -30,3 +31,4 @@ url {
   src: "https://github.com/janestreet/ppx_expect/archive/v0.14.1.tar.gz"
   checksum: "md5=9cc03dcabb00c72e17f7f5b0e4d28603"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_expect"]

--- a/packages/ppx_expect-windows/ppx_expect-windows.v0.16.0/opam
+++ b/packages/ppx_expect-windows/ppx_expect-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_expect" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "4.14.0"}
@@ -31,3 +32,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_expect-v0.16.0.tar.gz"
 checksum: "sha256=e0795a0ae2d576758aaaa685440951b28fe75d072d88f5c6bf415fb1a44e423c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_expect"]

--- a/packages/ppx_expect-windows/ppx_expect-windows.v0.17.2/opam
+++ b/packages/ppx_expect-windows/ppx_expect-windows.v0.17.2/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_expect" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "5.1.0"}
@@ -39,3 +40,4 @@ url {
     "sha512=c6394522da7f1e03df5d2f62766aa8534c09a12efff7908cc1215b06959e6eeaa2cb85514cd5def1582db66455ed922024387f28b84b4412aed4879ea905c38a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_expect"]

--- a/packages/ppx_expect-windows/ppx_expect-windows.v0.17.3/opam
+++ b/packages/ppx_expect-windows/ppx_expect-windows.v0.17.3/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_expect" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"           {>= "5.1.0"}
@@ -39,3 +40,4 @@ url {
     "sha512=d26364f2c7c0a3d83e5ecc144f77875a00887853c72c03e0122d658acb4d1cb4c6d77fabc1222d775663db74f0345be2a33518dffac9feef57ece5e9e40dc709"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_expect"]

--- a/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.12.0/opam
+++ b/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fields_conv" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"     {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_fields_conv-v0.12.0.tar.gz"
   checksum: "md5=5bdf701197abc0dd4145a489912e49aa"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fields_conv"]

--- a/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.14.2/opam
+++ b/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.14.2/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fields_conv" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"     {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://github.com/janestreet/ppx_fields_conv/archive/v0.14.2.tar.gz"
   checksum: "md5=f9ff1b882775718cba29bd67839405f0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fields_conv"]

--- a/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.16.0/opam
+++ b/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fields_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"     {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_fields_conv-v0.16.0.tar.gz"
 checksum: "sha256=b098fab38b5204114623a791e7034ff1316e676ba984ca70cadb4084dfc61898"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fields_conv"]

--- a/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.17.0/opam
+++ b/packages/ppx_fields_conv-windows/ppx_fields_conv-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fields_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"     {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_fields_conv/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=f22ce415852181fbea91b344f4ce4dcddbfab584741924d21ad78db25eb8e16a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fields_conv"]

--- a/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.14.0/opam
+++ b/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fixed_literal/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fixed_literal" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -26,3 +27,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_fixed_literal-v0.14.0.tar.gz"
   checksum: "md5=960bff66d1119cef42c16027e204554f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fixed_literal"]

--- a/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.16.0/opam
+++ b/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fixed_literal/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fixed_literal" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_fixed_literal-v0.16.0.tar.gz"
 checksum: "sha256=a7d1a3d4f8ac3e9db9a6e03a8fb58d07c2b9c4050d154d782c4057789e488339"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fixed_literal"]

--- a/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.17.0/opam
+++ b/packages/ppx_fixed_literal-windows/ppx_fixed_literal-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fixed_literal/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_fixed_literal" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_fixed_literal/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=8523872846b1e5ee7461eb55c912be4039b183de1cf2768045a6d51701a08400"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_fixed_literal"]

--- a/packages/ppx_globalize-windows/ppx_globalize-windows.v0.16.0/opam
+++ b/packages/ppx_globalize-windows/ppx_globalize-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_globalize" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_globalize-v0.16.0.tar.gz"
 checksum: "sha256=9068d7b4b765112974b17dd354cadf007f044afb11d2f99cd45b2e3b99ab491b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_globalize"]

--- a/packages/ppx_globalize-windows/ppx_globalize-windows.v0.17.0/opam
+++ b/packages/ppx_globalize-windows/ppx_globalize-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_globalize" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_globalize/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=42a28764e39f641abfc723ec755c68f0b6467bf7f5057c6f326cef2c34e73618"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_globalize"]

--- a/packages/ppx_globalize-windows/ppx_globalize-windows.v0.17.2/opam
+++ b/packages/ppx_globalize-windows/ppx_globalize-windows.v0.17.2/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_globalize/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_globalize" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -32,3 +33,4 @@ url {
     "sha512=9eb4908e8cd92ed79a73fb82a70d9f68fcdeec58e7b2e4e37b536716f4bf4f31866376cb1102cb44e62a40b4ead3c6d5d448872a62803ebb3ea7284c9d082b4a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_globalize"]

--- a/packages/ppx_hash-windows/ppx_hash-windows.v0.14.0/opam
+++ b/packages/ppx_hash-windows/ppx_hash-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_hash" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.04.2"}
@@ -28,3 +29,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_hash-v0.14.0.tar.gz"
   checksum: "md5=b78aee19bb4469731f9626b04fe7f341"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_hash"]

--- a/packages/ppx_hash-windows/ppx_hash-windows.v0.15.0/opam
+++ b/packages/ppx_hash-windows/ppx_hash-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_hash" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.08.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/ppx_hash-v0.15.0.tar.gz"
 checksum: "sha256=45bb666a0f93aab5bc120126c4c7d4081d611c64969606799248b2d8418d1711"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_hash"]

--- a/packages/ppx_hash-windows/ppx_hash-windows.v0.16.0/opam
+++ b/packages/ppx_hash-windows/ppx_hash-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_hash" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.14.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_hash-v0.16.0.tar.gz"
 checksum: "sha256=9b012546b7b9278bfd536f802fb6da88a11ebb5340d8aa47e9bf49acbf13b6e5"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_hash"]

--- a/packages/ppx_hash-windows/ppx_hash-windows.v0.17.0/opam
+++ b/packages/ppx_hash-windows/ppx_hash-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_hash" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -32,3 +33,4 @@ url {
 src: "https://github.com/janestreet/ppx_hash/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=8c8acae276a349d412eab9112cc3afa996d26ad4a01f2882121fc0adee0dd05e"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_hash"]

--- a/packages/ppx_here-windows/ppx_here-windows.v0.14.0/opam
+++ b/packages/ppx_here-windows/ppx_here-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_here/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_here" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_here-v0.14.0.tar.gz"
   checksum: "md5=bb3bbde0964a1f866de09f3df44def4d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_here"]

--- a/packages/ppx_here-windows/ppx_here-windows.v0.16.0/opam
+++ b/packages/ppx_here-windows/ppx_here-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_here/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_here" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_here-v0.16.0.tar.gz"
 checksum: "sha256=278198b92500c306fab3411e3dede264d678f203eb3295dd8dd79b70ed9273f0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_here"]

--- a/packages/ppx_here-windows/ppx_here-windows.v0.17.0/opam
+++ b/packages/ppx_here-windows/ppx_here-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_here/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_here" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/ppx_here/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=27ac69db34a5ff0efbf6e3c52d52dda46d1e5d5db4d14fb4d8c20370b932a913"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_here"]

--- a/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.16.0/opam
+++ b/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_ignore_instrumentat
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_ignore_instrumentation" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_ignore_instrumentation-v0.16.0.tar.gz"
 checksum: "sha256=522f50ef213300812658b5ea260299c072c24130502bde7e4f74eeda4c709305"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_ignore_instrumentation"]

--- a/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.17.0/opam
+++ b/packages/ppx_ignore_instrumentation-windows/ppx_ignore_instrumentation-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_ignore_instrumentat
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_ignore_instrumentation" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://github.com/janestreet/ppx_ignore_instrumentation/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=529aa92cc08a2ccb76fa361326fa7d4bbdfa2a7489c4f1c3a295658d3c758311"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_ignore_instrumentation"]

--- a/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.14.1/opam
+++ b/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_inline_test" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -24,3 +25,4 @@ url {
   src: "https://github.com/janestreet/ppx_inline_test/archive/v0.14.1.tar.gz"
   checksum: "md5=132754f0757188c3b700a2c5b6a2fb3f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_inline_test"]

--- a/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.16.0/opam
+++ b/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_inline_test" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_inline_test-v0.16.0.tar.gz"
 checksum: "sha256=216462f8fe988587d1e90f4a10aeb38664facb6eaeb3df60a32e9fb1a6bfbc67"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_inline_test"]

--- a/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.17.0/opam
+++ b/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_inline_test" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_inline_test/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=b71e4f01ab8aed418a3358688241a94b6d16d723deec7caaf5e4e917c2a76d2c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_inline_test"]

--- a/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.17.1/opam
+++ b/packages/ppx_inline_test-windows/ppx_inline_test-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_inline_test" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
     "sha512=e5c2dc8e519bbdadb5b1472ee5c5d08c547395e46c294962f1ac830461bb2d30d16894395ba95866713a099ef3565d83e67dda48d6ed26b55ad7cb36a8f7f6aa"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_inline_test"]

--- a/packages/ppx_jane-windows/ppx_jane-windows.v0.16.0/opam
+++ b/packages/ppx_jane-windows/ppx_jane-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_jane/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_jane" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"                       {>= "4.14.0"}
@@ -76,3 +77,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_jane-v0.16.0.tar.gz"
 checksum: "sha256=9d53b01dd2e38bbe82b6927f43fa27e347418045409fd2cd3e2a203a9951c133"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_jane"]

--- a/packages/ppx_jane-windows/ppx_jane-windows.v0.17.0/opam
+++ b/packages/ppx_jane-windows/ppx_jane-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_jane/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_jane" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"                       {>= "5.1.0"}
@@ -79,3 +80,4 @@ url {
 src: "https://github.com/janestreet/ppx_jane/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=4dcf29dbb093f57fdda18b659739b255b66dc5566b6c4c8a35caa3ce8666fa65"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_jane"]

--- a/packages/ppx_js_style-windows/ppx_js_style-windows.v0.16.0/opam
+++ b/packages/ppx_js_style-windows/ppx_js_style-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_js_style/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_js_style" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -30,3 +31,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_js_style-v0.16.0.tar.gz"
 checksum: "sha256=a63789aaf1b2301d60d29a67f8bae9ba127d98a4f004ab9567b8f16b3c885de0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_js_style"]

--- a/packages/ppx_let-windows/ppx_let-windows.v0.14.0/opam
+++ b/packages/ppx_let-windows/ppx_let-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_let" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_let-v0.14.0.tar.gz"
   checksum: "md5=faf5b4b69ef2595916f74fff251a9d2c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_let"]

--- a/packages/ppx_let-windows/ppx_let-windows.v0.16.0/opam
+++ b/packages/ppx_let-windows/ppx_let-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_let" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_let-v0.16.0.tar.gz"
 checksum: "sha256=2f4afb3100f4f0ae87be781b0ca6710f0a360ee8edd7eeaeb7574eca4d8be65c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_let"]

--- a/packages/ppx_let-windows/ppx_let-windows.v0.17.0/opam
+++ b/packages/ppx_let-windows/ppx_let-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_let" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_let/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=6bf57833ce402720fad8ef7aabda111c0a8640cf4441df42210eb62da8a48d78"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_let"]

--- a/packages/ppx_let-windows/ppx_let-windows.v0.17.1/opam
+++ b/packages/ppx_let-windows/ppx_let-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_let" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -32,3 +33,4 @@ url {
     "sha512=bd08d0bc7f37dff97a1500fdd145e978e9693382c5ac11305751a60d11f0ecea4afc319920c804f5e7b8ebadde365c31564851a14c41e9cac2956fc7b5a71a9d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_let"]

--- a/packages/ppx_log-windows/ppx_log-windows.v0.16.0/opam
+++ b/packages/ppx_log-windows/ppx_log-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_log/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_log" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"            {>= "4.14.0"}
@@ -32,3 +33,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_log-v0.16.0.tar.gz"
 checksum: "sha256=94d92ab27d5f1e4e50d269d23e33e6819a4a1a613fe0312f59201e3c1d74faf8"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_log"]

--- a/packages/ppx_log-windows/ppx_log-windows.v0.17.0/opam
+++ b/packages/ppx_log-windows/ppx_log-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_log/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_log" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"             {>= "5.1.0"}
@@ -50,3 +51,4 @@ url {
 src: "https://github.com/janestreet/ppx_log/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=2208f047b699d0661e94415868e8e9e4a6e5287a8eceaf7318f572ccd622859a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_log"]

--- a/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.14.0/opam
+++ b/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_module_timer/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_module_timer" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -28,3 +29,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_module_timer-v0.14.0.tar.gz"
   checksum: "md5=7ec9de2d5f07a1ceecdbefce0f0dea2c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_module_timer"]

--- a/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.16.0/opam
+++ b/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_module_timer/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_module_timer" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_module_timer-v0.16.0.tar.gz"
 checksum: "sha256=2aee6ebec3dc3378a88a245a2c4f7c6314e96c377a02f390622c125bcef41f74"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_module_timer"]

--- a/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.17.0/opam
+++ b/packages/ppx_module_timer-windows/ppx_module_timer-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_module_timer/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_module_timer" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -30,3 +31,4 @@ url {
 src: "https://github.com/janestreet/ppx_module_timer/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=fcc39a8623f7c4e1bb40ce6ed5e9af596938f88f5718f01417ed39b11fc5e264"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_module_timer"]

--- a/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.16.0/opam
+++ b/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_optcomp" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_optcomp-v0.16.0.tar.gz"
 checksum: "sha256=99b209084a5375dafce4c6b128979661ab2ab6bf898a6872d596e65ded590ba2"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_optcomp"]

--- a/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.17.0/opam
+++ b/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_optcomp" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_optcomp/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=a62010eaf74035ee48ef2095da464f16fb6a087948a6c9d69dd1551c4836c64b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_optcomp"]

--- a/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.17.1/opam
+++ b/packages/ppx_optcomp-windows/ppx_optcomp-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_optcomp" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
     "sha512=2e7c41f168c004cf3be1cd768a5406c61af135c0b084ffdfc39555b4be8c21a227c56cffbfb66de8dc3de35f735277d330f3cc6762e6ba8708deebb78f9fd49b"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_optcomp"]

--- a/packages/ppx_optional-windows/ppx_optional-windows.v0.14.0/opam
+++ b/packages/ppx_optional-windows/ppx_optional-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optional/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_optional" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -26,3 +27,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_optional-v0.14.0.tar.gz"
   checksum: "md5=0c85a3233f660a500f7d7481a1ab3c6c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_optional"]

--- a/packages/ppx_optional-windows/ppx_optional-windows.v0.16.0/opam
+++ b/packages/ppx_optional-windows/ppx_optional-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optional/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_optional" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_optional-v0.16.0.tar.gz"
 checksum: "sha256=70f94f6794dc4ba39db69253988af429e45f608dc12d71b792a8551219bcbfab"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_optional"]

--- a/packages/ppx_optional-windows/ppx_optional-windows.v0.17.0/opam
+++ b/packages/ppx_optional-windows/ppx_optional-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optional/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_optional" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://github.com/janestreet/ppx_optional/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=809acb833048508f48c74422a5f74e4ef621807376eb5753b98bbd8f3df409bc"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_optional"]

--- a/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.14.0/opam
+++ b/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pipebang/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_pipebang" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -23,3 +24,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_pipebang-v0.14.0.tar.gz"
   checksum: "md5=fa42f83b1851956dbae5716fab4776d3"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_pipebang"]

--- a/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.16.0/opam
+++ b/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pipebang/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_pipebang" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -23,3 +24,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_pipebang-v0.16.0.tar.gz"
 checksum: "sha256=b9e447e49cdbc55fb0f66401ed0d7b6522fbec6518a43f7a4905af67e41efa66"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_pipebang"]

--- a/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.17.0/opam
+++ b/packages/ppx_pipebang-windows/ppx_pipebang-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pipebang/index.html
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_pipebang" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://github.com/janestreet/ppx_pipebang/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=b50995e2e31fa1f93c2468780f5f082e0859782f8826cc05ad3ec2ad4f8c02ff"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_pipebang"]

--- a/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.16.0/opam
+++ b/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_sexp_conv-v0.16.0.tar.gz"
 checksum: "sha256=41bcb7a3b33bdf50428408bfaf1dbcede528a488ac8c436ce710681bcd91200d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_conv"]

--- a/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.17.0/opam
+++ b/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://github.com/janestreet/ppx_sexp_conv/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=4af4f99d774fab77bf63ba2298fc288c356a88bdac0a37e3a23b0d669410ee5a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_conv"]

--- a/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.17.1/opam
+++ b/packages/ppx_sexp_conv-windows/ppx_sexp_conv-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.htm
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -33,3 +34,4 @@ url {
     "sha512=036582cbcd49aad0737bbbdf5f680192e55a9f3051c8dece439a6c6ea989b59077c88130d833b01a38d990e563f7dde9f5be7e1cd0ffaaf59bd913d6fbd63bb3"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_conv"]

--- a/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.14.1/opam
+++ b/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_message/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_message" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.04.2"}
@@ -29,3 +30,4 @@ url {
   src: "https://github.com/janestreet/ppx_sexp_message/archive/v0.14.1.tar.gz"
   checksum: "md5=a6f4478ba28e7f16cd37789e64a7cb79"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_message"]

--- a/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.16.0/opam
+++ b/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_message/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_message" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.14.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_sexp_message-v0.16.0.tar.gz"
 checksum: "sha256=1829931dc8670232b4687b74187777061b0df5a667478e6b9dad324e30a47d38"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_message"]

--- a/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.17.0/opam
+++ b/packages/ppx_sexp_message-windows/ppx_sexp_message-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_message/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_message" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -30,3 +31,4 @@ url {
 src: "https://github.com/janestreet/ppx_sexp_message/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=2a02e4943106f4e87a3b2e17e5127859a4d01a4bdbe477f2084858a9962c47ee"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_message"]

--- a/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.14.0/opam
+++ b/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_value/index.ht
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_value" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.04.2"}
@@ -29,3 +30,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_sexp_value-v0.14.0.tar.gz"
   checksum: "md5=8bc8a75c992e8af371dfd71804ac2133"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_value"]

--- a/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.16.0/opam
+++ b/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_value/index.ht
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_value" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "4.14.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_sexp_value-v0.16.0.tar.gz"
 checksum: "sha256=74d4015a4cf2582bb7d3bcaefa91d0a89c6f3cfb423d2983ec205c007631d369"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_value"]

--- a/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.17.0/opam
+++ b/packages/ppx_sexp_value-windows/ppx_sexp_value-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_value/index.ht
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_sexp_value" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"         {>= "5.1.0"}
@@ -30,3 +31,4 @@ url {
 src: "https://github.com/janestreet/ppx_sexp_value/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=599e72775285dc5a3042e4717d79f6ff1cb713ef5d7b2c46c5ee2443ad2d6e3c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_sexp_value"]

--- a/packages/ppx_stable-windows/ppx_stable-windows.v0.14.1/opam
+++ b/packages/ppx_stable-windows/ppx_stable-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_stable" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://github.com/janestreet/ppx_stable/archive/v0.14.1.tar.gz"
   checksum: "md5=78fd32fd0e72ebfd8e522008949066b5"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_stable"]

--- a/packages/ppx_stable-windows/ppx_stable-windows.v0.16.0/opam
+++ b/packages/ppx_stable-windows/ppx_stable-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_stable" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_stable-v0.16.0.tar.gz"
 checksum: "sha256=91b8e7540662c94922d8f7cb7afa7ea73e8890341e65290785c2aca0c2173094"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_stable"]

--- a/packages/ppx_stable-windows/ppx_stable-windows.v0.17.0/opam
+++ b/packages/ppx_stable-windows/ppx_stable-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_stable" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_stable/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=292175401b75bc23d9fb9a0f0d13547700b495815f698d481a519d9462683900"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_stable"]

--- a/packages/ppx_stable-windows/ppx_stable-windows.v0.17.1/opam
+++ b/packages/ppx_stable-windows/ppx_stable-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_stable" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
     "sha512=aff081814ac95dc4ebcaa275ccd6fb4e6d7de5de4ef3fc6a633debeeae213136d46c526fb8dc33896542dcde0319957d04308f4a5b8012342fc6a9ccfb5dc072"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_stable"]

--- a/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.16.0/opam
+++ b/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable_witness/inde
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_stable_witness" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_stable_witness-v0.16.0.tar.gz"
 checksum: "sha256=4f9857612d9d65c3844bd8940b946a19472e2d5b9df29e91c829d6d0aa78c5ef"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_stable_witness"]

--- a/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.17.0/opam
+++ b/packages/ppx_stable_witness-windows/ppx_stable_witness-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable_witness/inde
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_stable_witness" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/ppx_stable_witness/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=052db5d52ccacaab30ead1a4192ad021ee00c235a73c09b7918acabcee4a0cda"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_stable_witness"]

--- a/packages/ppx_string-windows/ppx_string-windows.v0.14.1/opam
+++ b/packages/ppx_string-windows/ppx_string-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_string" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -28,3 +29,4 @@ url {
   src: "https://github.com/janestreet/ppx_string/archive/v0.14.1.tar.gz"
   checksum: "md5=5765a8ca47970b2290fbd7c5d589b449"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_string"]

--- a/packages/ppx_string-windows/ppx_string-windows.v0.15.0/opam
+++ b/packages/ppx_string-windows/ppx_string-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_string" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.08.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/ppx_string-v0.15.0.tar.gz"
 checksum: "sha256=f33d4956792fd022c63f8eef4269fcbf77aa06402d7b17df80cb493482b71393"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_string"]

--- a/packages/ppx_string-windows/ppx_string-windows.v0.16.0/opam
+++ b/packages/ppx_string-windows/ppx_string-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_string" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_string-v0.16.0.tar.gz"
 checksum: "sha256=1f5b999446a8eeb666feb493eb6e593a66819afe610d7f95ef424b151d148336"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_string"]

--- a/packages/ppx_string-windows/ppx_string-windows.v0.17.0/opam
+++ b/packages/ppx_string-windows/ppx_string-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_string" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/ppx_string/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=06b4e061fb5e2b2a85298c9829cc31a1af0a9b8e63fdee9048c76ec8d52d16ef"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_string"]

--- a/packages/ppx_string_conv-windows/ppx_string_conv-windows.v0.17.0/opam
+++ b/packages/ppx_string_conv-windows/ppx_string_conv-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string_conv/index.h
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_string_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"          {>= "5.1.0"}
@@ -32,3 +33,4 @@ url {
 src: "https://github.com/janestreet/ppx_string_conv/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=2e43def9a3f13f46ac8465fa81d51784d080083539b88d3c6e8a649d5ae0fdb0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_string_conv"]

--- a/packages/ppx_tools_versioned-windows/ppx_tools_versioned-windows.5.2.2/opam
+++ b/packages/ppx_tools_versioned-windows/ppx_tools_versioned-windows.5.2.2/opam
@@ -11,6 +11,7 @@ dev-repo: "git://github.com/ocaml-ppx/ppx_tools_versioned.git"
 tags: [ "syntax" ]
 build: [
   ["dune" "build" "-p" "ppx_tools_versioned" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.02.0"}
@@ -26,3 +27,4 @@ url {
     "sha512=68c168ebc01af46fe8766ad7e36cc778caabb97d8eb303db284d106450cb79974c2a640ce459e197630b9e84b02caa24b59c97c9a8d39ddadc7efc7284e42a70"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_tools_versioned"]

--- a/packages/ppx_tools_versioned-windows/ppx_tools_versioned-windows.5.4.0/opam
+++ b/packages/ppx_tools_versioned-windows/ppx_tools_versioned-windows.5.4.0/opam
@@ -13,6 +13,7 @@ synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
 tags: [ "syntax" ]
 build: [
   ["dune" "build" "-p" "ppx_tools_versioned" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.02.0"}
@@ -24,3 +25,4 @@ url {
   src: "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.4.0.tar.gz"
   checksum: "md5=3e809a11cae99f57c051d3d0100311f6"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_tools_versioned"]

--- a/packages/ppx_tydi-windows/ppx_tydi-windows.v0.16.0/opam
+++ b/packages/ppx_tydi-windows/ppx_tydi-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_tydi" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_tydi-v0.16.0.tar.gz"
 checksum: "sha256=a363153a1f58b35b789321dca9b5b03da46bc1c9152a38d307ffb338b3e25ac6"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_tydi"]

--- a/packages/ppx_tydi-windows/ppx_tydi-windows.v0.17.0/opam
+++ b/packages/ppx_tydi-windows/ppx_tydi-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_tydi" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/ppx_tydi/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=8d22dc50f0ec75380b893063a2294555dc325d21777bc09d2c6e201b391e4265"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_tydi"]

--- a/packages/ppx_tydi-windows/ppx_tydi-windows.v0.17.1/opam
+++ b/packages/ppx_tydi-windows/ppx_tydi-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_tydi/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_tydi" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"  {>= "5.1.0"}
@@ -30,3 +31,4 @@ url {
     "sha512=f4af5b32a537cb72ffc6a331f73e90eb650e6116ca130d785eda78fb9de5764a1d990ff6929fd6fb695bfeb35d2685f4b35c344125208733b08953ca13410cc5"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_tydi"]

--- a/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.14.2/opam
+++ b/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.14.2/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_typerep_conv" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"   {>= "4.04.2"}
@@ -26,3 +27,4 @@ url {
   checksum: "md5=33ce6d705b7323772379712511daac0b"
 }
 
+install: ["dune" "install" "-x" "windows" "-p" "ppx_typerep_conv"]

--- a/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.16.0/opam
+++ b/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_typerep_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"   {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_typerep_conv-v0.16.0.tar.gz"
 checksum: "sha256=ffd565ee7b30dbb9c57e38c0cda8b33b4153edb3adae05796e0f97a7780f0d9a"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_typerep_conv"]

--- a/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.17.0/opam
+++ b/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_typerep_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"   {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_typerep_conv/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=eef7c7ff1e94343dd1bd25f8bf1f74b5f3adc097b454f0c1adb7e4962754809c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_typerep_conv"]

--- a/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.17.1/opam
+++ b/packages/ppx_typerep_conv-windows/ppx_typerep_conv-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_typerep_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"   {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
     "sha512=8184722762d1e848b16f5409ecf478d0e60fadac590fba1d9355bd7efa09c25e4b87cdc0d117a77386b8da6fcf2bf13c7cf6150f3090686e354a2354ad52e1c5"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_typerep_conv"]

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.12.0/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_variants_conv" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_variants_conv-v0.12.0.tar.gz"
   checksum: "md5=0661be686b476e1a9c6e891e45fb3581"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_variants_conv"]

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.14.1/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.14.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_variants_conv" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://github.com/janestreet/ppx_variants_conv/archive/v0.14.1.tar.gz"
   checksum: "md5=5967b6bdf8d1d95ac25f79ffa925397d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_variants_conv"]

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.16.0/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_variants_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "4.14.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/ppx_variants_conv-v0.16.0.tar.gz"
 checksum: "sha256=20ab1035bf7661ebad1ad0745bce434616488f56a1ed3a121a8a372ec96885e4"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_variants_conv"]

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.17.0/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_variants_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://github.com/janestreet/ppx_variants_conv/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=b66d1fe64d0adc2e7da5474f270467f1eddcba880f398ee9b0e7e0946c65b6c4"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_variants_conv"]

--- a/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.17.1/opam
+++ b/packages/ppx_variants_conv-windows/ppx_variants_conv-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppx_variants_conv" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"       {>= "5.1.0"}
@@ -31,3 +32,4 @@ url {
     "sha512=23c9866b2f07e8e55fb7c19bbddbd1c424410fcb590c2b5039b0d194274fd5cfe6a58da55db83cfaddc698c00e42cad95756f49ef0f3d3163fd5f362ebd5e25a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppx_variants_conv"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.22.2/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.22.2/opam
@@ -34,17 +34,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {pinned}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ppxlib"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "ppxlib" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 x-commit-hash: "3cf57772fef4666a2992041cf3a670dd2be98603"
@@ -56,3 +47,4 @@ url {
     "sha512=6010a59be6af873eaf193670f9cc8c9a7f091cfd89ec6c5b68d1f0c72d7c6015eec6371c009fc473cf2cb37d24f0934d04d0eacefa567a4945234197c3b31741"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.26.0/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.26.0/opam
@@ -45,6 +45,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 url {
@@ -56,3 +57,4 @@ url {
   ]
 }
 x-commit-hash: "18b1ad68b59d151d662147661e43b159ac491f68"
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.29.1/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.29.1/opam
@@ -49,6 +49,7 @@ build: [
     "@install"
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 url {
@@ -60,3 +61,4 @@ url {
   ]
 }
 x-commit-hash: "36fcba0408b78963a730e0be92abdbab00b0ea26"
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.32.0/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.32.0/opam
@@ -36,17 +36,8 @@ conflicts: [
   "base-effects-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "ppxlib"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ppxlib" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 url {
@@ -58,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "ad46a4c87f99a44dc70b2ec4c42caec2ccacc3c3"
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.34.0/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.34.0/opam
@@ -43,13 +43,16 @@ build: [
     "dune"
     "build"
     "-p"
-    "ppxlib" "-x" "windows"
+    "ppxlib"
+    "-x"
+    "windows"
     "-j"
     jobs
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 x-maintenance-intent: ["(latest)"]
@@ -62,3 +65,4 @@ url {
   ]
 }
 x-commit-hash: "cc9d995de93ed8109c3d32c76d9b287999e8a1d1"
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.37.0/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.37.0/opam
@@ -43,13 +43,16 @@ build: [
     "dune"
     "build"
     "-p"
-    "ppxlib" "-x" "windows"
+    "ppxlib"
+    "-x"
+    "windows"
     "-j"
     jobs
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 x-maintenance-intent: ["(latest)"]
@@ -62,3 +65,4 @@ url {
   ]
 }
 x-commit-hash: "df39675d8ff0c3490ece8157c681691cfb67fdaf"
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib-windows/ppxlib-windows.0.8.0/opam
+++ b/packages/ppxlib-windows/ppxlib-windows.0.8.0/opam
@@ -9,6 +9,7 @@ license: "MIT"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "ppxlib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"                   {>= "4.04.1"}
@@ -40,3 +41,4 @@ url {
     "https://github.com/ocaml-ppx/ppxlib/archive/0.8.0.tar.gz"
   checksum: "md5=9b1cfe1ae58d7ad851ed5618c1bf64a0"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib"]

--- a/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.0/opam
+++ b/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppxlib_jane" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0" & < "5.3"}
@@ -24,3 +25,4 @@ url {
 src: "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=42757d7b44a5f2a766778e6b4710100c6ef9d0c074eb3e7fa4c69647336d8398"
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib_jane"]

--- a/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.2/opam
+++ b/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.2/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppxlib_jane" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.3.0"}
@@ -28,3 +29,4 @@ url {
     "sha512=342e034d44d14958869e643befb0e749d4de3ca0040891ab51592e2583bc5bb827bdaa5bd06966ac536151d160997aef79baa090247d1649a6b5849a359744d8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib_jane"]

--- a/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.4/opam
+++ b/packages/ppxlib_jane-windows/ppxlib_jane-windows.v0.17.4/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppxlib_jane/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "ppxlib_jane" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.3.0"}
@@ -28,3 +29,4 @@ url {
     "sha512=e2931de633d9dcce2ca121e1cf117e159af4ccc52a7e420c328021da0145b6b90194e4545f97afe9cd032c04c6bc2563faa2d852ad45b041b014c688153799d6"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ppxlib_jane"]

--- a/packages/prometheus-app-windows/prometheus-app-windows.1.2/opam
+++ b/packages/prometheus-app-windows/prometheus-app-windows.1.2/opam
@@ -40,6 +40,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "prometheus-app" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/prometheus.git"
 url {
@@ -51,3 +52,4 @@ url {
   ]
 }
 x-commit-hash: "d1669d0e0d7e44b104755a0fd9700ae87e140f34"
+install: ["dune" "install" "-x" "windows" "-p" "prometheus-app"]

--- a/packages/prometheus-windows/prometheus-windows.1.2/opam
+++ b/packages/prometheus-windows/prometheus-windows.1.2/opam
@@ -20,6 +20,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "prometheus" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirage/prometheus.git"
 description: """
@@ -40,3 +41,4 @@ url {
   ]
 }
 x-commit-hash: "d1669d0e0d7e44b104755a0fd9700ae87e140f34"
+install: ["dune" "install" "-x" "windows" "-p" "prometheus"]

--- a/packages/re-windows/re-windows.1.11.0/opam
+++ b/packages/re-windows/re-windows.1.11.0/opam
@@ -16,8 +16,8 @@ dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "re" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.03"}
   "dune" {>= "2.0"}
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "2dd38515c76c40299596d39f18d9b9a20f00d788"
+install: ["dune" "install" "-x" "windows" "-p" "re"]

--- a/packages/re-windows/re-windows.1.12.0/opam
+++ b/packages/re-windows/re-windows.1.12.0/opam
@@ -15,8 +15,8 @@ dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
 
 build: [
   ["dune" "build" "-p" "re" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.12"}
   "dune" {>= "2.0"}
@@ -41,3 +41,4 @@ url {
   ]
 }
 x-commit-hash: "f09672608781dc05172ad980a6e9a483c3b9d534"
+install: ["dune" "install" "-x" "windows" "-p" "re"]

--- a/packages/result-windows/result-windows.1.4/opam
+++ b/packages/result-windows/result-windows.1.4/opam
@@ -5,7 +5,10 @@ homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD3"
-build: [["dune" "build" "-p" "result" "-j" jobs "-x" "windows"]]
+build: [
+  ["dune" "build" "-p" "result" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows"
   "dune" {build & >= "1.0"}
@@ -20,3 +23,4 @@ url {
     "https://github.com/janestreet/result/archive/1.4.tar.gz"
   checksum: "md5=d3162dbc501a2af65c8c71e0866541da"
 }
+install: ["dune" "install" "-x" "windows" "-p" "result"]

--- a/packages/result-windows/result-windows.1.5/opam
+++ b/packages/result-windows/result-windows.1.5/opam
@@ -5,7 +5,10 @@ homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
-build: [["dune" "build" "-p" "result" "-j" jobs "-x" "windows"]]
+build: [
+  ["dune" "build" "-p" "result" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
+]
 depends: [
   "ocaml-windows"
   "dune" {>= "1.0"}
@@ -20,3 +23,4 @@ url {
     "https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz"
   checksum: "md5=1b82dec78849680b49ae9a8a365b831b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "result"]

--- a/packages/samplerate-windows/samplerate-windows.0.1.5/opam
+++ b/packages/samplerate-windows/samplerate-windows.0.1.5/opam
@@ -13,17 +13,8 @@ depends: [
   "ocaml-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "samplerate"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "samplerate" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["libsamplerate"] {os-distribution = "mxe"}
@@ -36,3 +27,4 @@ url {
     "sha512=54f337b386c0c2195ccc347e3a9f10497053be42d208b865d7fa64b0821c804b9c9c9d6f9aec84a592f29c719a5ff04a8e45610f14f7bf1a4cc326faaf864531"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "samplerate"]

--- a/packages/samplerate-windows/samplerate-windows.0.1.6/opam
+++ b/packages/samplerate-windows/samplerate-windows.0.1.6/opam
@@ -14,17 +14,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {pinned}
-  [
-    "dune"
-    "build"
-    "-p"
-    "samplerate"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "samplerate" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-samplerate.git"
 depexts: [
@@ -37,3 +28,4 @@ url {
     "sha512=7fee25fdacdc282217bf810628b1b899f0df41c6111dcfd6933c9b6737ce955c13bbb95e15d78f98dad7c9abf29ef64e45a62d79550b33bf5d955ce1526889e8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "samplerate"]

--- a/packages/saturn-windows/saturn-windows.0.4.1/opam
+++ b/packages/saturn-windows/saturn-windows.0.4.1/opam
@@ -14,17 +14,8 @@ depends: [
   "saturn_lockfree-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "saturn"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "saturn" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
 url {
@@ -36,3 +27,4 @@ url {
   ]
 }
 x-commit-hash: "978b876ab512828ba36c068944dac64682784f9e"
+install: ["dune" "install" "-x" "windows" "-p" "saturn"]

--- a/packages/saturn-windows/saturn-windows.0.5.0/opam
+++ b/packages/saturn-windows/saturn-windows.0.5.0/opam
@@ -13,17 +13,8 @@ depends: [
   "saturn_lockfree-windows" {= version}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "saturn"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "saturn" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
 url {
@@ -35,3 +26,4 @@ url {
   ]
 }
 x-commit-hash: "60dd353c9b9b6fae8a3a61d0fcf30d599e0a68a9"
+install: ["dune" "install" "-x" "windows" "-p" "saturn"]

--- a/packages/saturn_lockfree-windows/saturn_lockfree-windows.0.4.1/opam
+++ b/packages/saturn_lockfree-windows/saturn_lockfree-windows.0.4.1/opam
@@ -12,17 +12,8 @@ depends: [
   "domain_shims-windows" {>= "0.1.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "saturn_lockfree"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "saturn_lockfree" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
 url {
@@ -34,3 +25,4 @@ url {
   ]
 }
 x-commit-hash: "978b876ab512828ba36c068944dac64682784f9e"
+install: ["dune" "install" "-x" "windows" "-p" "saturn_lockfree"]

--- a/packages/saturn_lockfree-windows/saturn_lockfree-windows.0.5.0/opam
+++ b/packages/saturn_lockfree-windows/saturn_lockfree-windows.0.5.0/opam
@@ -15,17 +15,8 @@ depends: [
   "multicore-magic-windows" {>= "2.3.0"}
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "saturn_lockfree"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "saturn_lockfree" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
 url {
@@ -37,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "60dd353c9b9b6fae8a3a61d0fcf30d599e0a68a9"
+install: ["dune" "install" "-x" "windows" "-p" "saturn_lockfree"]

--- a/packages/sedlex-windows/sedlex-windows.2.0/opam
+++ b/packages/sedlex-windows/sedlex-windows.2.0/opam
@@ -18,6 +18,7 @@ dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 build: [
   ["dune" "build" "-x" "windows" "-p" "sedlex" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.02.3"}
@@ -33,3 +34,4 @@ url {
   src: "https://github.com/ocaml-community/sedlex/archive/v2.0.zip"
   checksum: "md5=807023962f25342b0a2c386a3742414c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sedlex"]

--- a/packages/sedlex-windows/sedlex-windows.2.1/opam
+++ b/packages/sedlex-windows/sedlex-windows.2.1/opam
@@ -18,6 +18,7 @@ dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 build: [
   ["dune" "build" "-x" "windows" "-p" "sedlex" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {"4.02.3"}
@@ -36,3 +37,4 @@ url {
     "sha512=7c937c5ed234ac6f97aacec5e9f185c4490ab8cc953d071b1bbb93983e5518c4c0fb96782a43348631270c7b4f3e0c5dc312777644724adf955f9a58070b3f12"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "sedlex"]

--- a/packages/sedlex-windows/sedlex-windows.2.2/opam
+++ b/packages/sedlex-windows/sedlex-windows.2.2/opam
@@ -18,6 +18,7 @@ dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 build: [
   ["dune" "build" "-p" "sedlex" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
@@ -39,3 +40,4 @@ url {
     "sha512=c38940654d8d2a4b8f627bc9109b0fd983c520d8db05bf4b514ddc05cf50946c086d3558dfced64cc8f2b4eaabc6155426eb44ee6d903e3520ebb65daadf990a"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "sedlex"]

--- a/packages/sedlex-windows/sedlex-windows.3.0/opam
+++ b/packages/sedlex-windows/sedlex-windows.3.0/opam
@@ -26,17 +26,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "sedlex"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "sedlex" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 doc: "https://ocaml-community.github.io/sedlex/index.html"
@@ -47,3 +38,4 @@ url {
     "sha512=564780b7af8b3ddd32c9164caa42fd24b2ff59e0bf9977bcee4c3ddea2be3f0c870bd95949b639c5f1942e0fa2604902f5cd3eb9041d59b6ee2367895df556df"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "sedlex"]

--- a/packages/sedlex-windows/sedlex-windows.3.2/opam
+++ b/packages/sedlex-windows/sedlex-windows.3.2/opam
@@ -24,17 +24,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "sedlex"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "sedlex" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 doc: "https://ocaml-community.github.io/sedlex/index.html"
@@ -46,3 +37,4 @@ url {
     "sha512=00e257d1b97e99d49028d2e38b20a05c6aa151c362991c37c17522bf58c19e273b762ea39dd9783ed9ecc60d11dadeabb0487e16b4af91536e45e7e18c86cfe9"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "sedlex"]

--- a/packages/sedlex-windows/sedlex-windows.3.7/opam
+++ b/packages/sedlex-windows/sedlex-windows.3.7/opam
@@ -24,15 +24,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "sedlex" "-x" "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "sedlex" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
 doc: "https://ocaml-community.github.io/sedlex/index.html"
@@ -44,3 +37,4 @@ url {
     "sha512=053bceea4944309705e6b8014381711a2c4f7f0ab235cd239e2d2f5a2dbd3efe1b1c2d533631a8545dacf563cdb5b7469fe53982ef79ace270ee8a4a471f1fe2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "sedlex"]

--- a/packages/sexplib-windows/sexplib-windows.v0.12.0/opam
+++ b/packages/sexplib-windows/sexplib-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -27,3 +28,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib-v0.12.0.tar.gz"
   checksum: "md5=a7f9f8a414aed6cc56901199cda020f6"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib"]

--- a/packages/sexplib-windows/sexplib-windows.v0.14.0/opam
+++ b/packages/sexplib-windows/sexplib-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.04.2"}
@@ -27,3 +28,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexplib-v0.14.0.tar.gz"
   checksum: "md5=6e230eae22face46cb8645e53e351067"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib"]

--- a/packages/sexplib-windows/sexplib-windows.v0.16.0/opam
+++ b/packages/sexplib-windows/sexplib-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "4.14.0"}
@@ -27,3 +28,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib-v0.16.0.tar.gz"
 checksum: "sha256=e564d5d1ca157314ba5fd64b4e89fa12c6cba8efee3becf6d09d7d9dda21ac5b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib"]

--- a/packages/sexplib-windows/sexplib-windows.v0.17.0/opam
+++ b/packages/sexplib-windows/sexplib-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"    {>= "5.1.0"}
@@ -28,3 +29,4 @@ url {
 src: "https://github.com/janestreet/sexplib/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=da863b42b81235fdcf45eb32c04fb8bde22ff446a779cfb6f989730a35103160"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib"]

--- a/packages/sexplib0-windows/sexplib0-windows.v0.12.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib0" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2"}
@@ -24,3 +25,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib0-v0.12.0.tar.gz"
   checksum: "md5=2486a25d3a94da9a94acc018b5f09061"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib0"]

--- a/packages/sexplib0-windows/sexplib0-windows.v0.14.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib0" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2" & < "5.0"}
@@ -24,3 +25,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexplib0-v0.14.0.tar.gz"
   checksum: "md5=37aff0af8f8f6f759249475684aebdc4"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib0"]

--- a/packages/sexplib0-windows/sexplib0-windows.v0.15.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.15.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib0" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2" & < "5.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/sexplib0-v0.15.0.tar.gz"
 checksum: "sha256=94462c00416403d2778493ac01ced5439bc388a68ac4097208159d62434aefba"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib0"]

--- a/packages/sexplib0-windows/sexplib0-windows.v0.16.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib0" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.08.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/sexplib0-v0.16.0.tar.gz"
 checksum: "sha256=86dba26468194512f789f2fb709063515a9cb4e5c4461c021c239a369590701d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib0"]

--- a/packages/sexplib0-windows/sexplib0-windows.v0.17.0/opam
+++ b/packages/sexplib0-windows/sexplib0-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "sexplib0" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.14.0"}
@@ -29,3 +30,4 @@ url {
     "sha512=ad387e40789fe70a11473db7e85fe017b801592624414e9030730b2e92ea08f98095fb6e9236430f33c801605ebee0a2a6284e0f618a26a7da4599d4fd9d395d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "sexplib0"]

--- a/packages/speex-windows/speex-windows.0.4.0/opam
+++ b/packages/speex-windows/speex-windows.0.4.0/opam
@@ -26,6 +26,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["speex"] {os-distribution = "mxe"}
@@ -38,3 +39,4 @@ url {
     "sha512=812dcd25336729a6bcacd80f6a54ffc984c08961ffa1b151b7a4fd36b5c9c5f6429bf6cc0a698aae3efa630be029bf93d0e55f070f5db2de1b1efa7a692ef3d8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "speex"]

--- a/packages/spelll-windows/spelll-windows.0.3/opam
+++ b/packages/spelll-windows/spelll-windows.0.3/opam
@@ -13,6 +13,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "@install" "-p" "spelll" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git://github.com/c-cube/spelll"
 url {
@@ -22,3 +23,4 @@ url {
     "sha512=5ba25cf300538bcb27bd63f272f001114b0f07a7fe45d287d33d13261d6c366ee59f897867d76fcabc898efd7ac400b598cb445f11051db7cb1448448f3a4020"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "spelll"]

--- a/packages/splittable_random-windows/splittable_random-windows.v0.14.0/opam
+++ b/packages/splittable_random-windows/splittable_random-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/splittable_random/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "splittable_random" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"            {>= "4.04.2"}
@@ -37,3 +38,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/splittable_random-v0.14.0.tar.gz"
   checksum: "md5=18ecdf4352883c70c48a3e02931b9521"
 }
+install: ["dune" "install" "-x" "windows" "-p" "splittable_random"]

--- a/packages/splittable_random-windows/splittable_random-windows.v0.16.0/opam
+++ b/packages/splittable_random-windows/splittable_random-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/splittable_random/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "splittable_random" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"            {>= "4.14.0"}
@@ -37,3 +38,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/splittable_random-v0.16.0.tar.gz"
 checksum: "sha256=e16f1b063f03e3c18ce39f2037bebf803e13f4e5bbe824f2481ff12d121ff6d3"
 }
+install: ["dune" "install" "-x" "windows" "-p" "splittable_random"]

--- a/packages/splittable_random-windows/splittable_random-windows.v0.17.0/opam
+++ b/packages/splittable_random-windows/splittable_random-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/splittable_random/index
 license: "MIT"
 build: [
   ["dune" "build" "-p" "splittable_random" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"            {>= "5.1.0"}
@@ -38,3 +39,4 @@ url {
 src: "https://github.com/janestreet/splittable_random/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=4f8adcade214d1f84e1073a35f4751154e73853649df581cce68d20dc6337ad2"
 }
+install: ["dune" "install" "-x" "windows" "-p" "splittable_random"]

--- a/packages/srt-windows/srt-windows.0.1.1/opam
+++ b/packages/srt-windows/srt-windows.0.1.1/opam
@@ -19,17 +19,8 @@ depends: [
   "posix-socket"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["libsrt"] {os-distribution = "mxe"}
@@ -41,3 +32,4 @@ url {
     "md5=299ed6660507f0a68b8b24e5617a0e4c"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.2.0/opam
+++ b/packages/srt-windows/srt-windows.0.2.0/opam
@@ -35,6 +35,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["libsrt"] {os-distribution = "mxe"}
@@ -47,3 +48,4 @@ url {
     "sha512=f42a685a60bd7b5b0be5c89177a9e1b948c8b64f6cacff6fa8988697d95c5746de84f1c9048ea931fe6ae53efeeeabcc669ad3332437898c2513e0d78c2fe293"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.2.1/opam
+++ b/packages/srt-windows/srt-windows.0.2.1/opam
@@ -23,17 +23,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["libsrt"] {os-distribution = "mxe"}
@@ -46,3 +37,4 @@ url {
     "sha512=17892b641930e0804aa187f41670038174e38d23c7748705af5c94bf68d9e0efe34d38fc4972cffe526be2ef6ebfc3cbf0edaf54baad83b17a3292430657f7a4"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.2.2/opam
+++ b/packages/srt-windows/srt-windows.0.2.2/opam
@@ -27,17 +27,8 @@ depexts: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-srt.git"
 url {
@@ -47,3 +38,4 @@ url {
     "sha512=05fa8294af8e649879cc8f06a34d1c1d62c1064d5638ac5fbdccd69d36f1edf4ac5df581913c63d6ce9ec468cad3a51cfa0e9a74560dec7e7b7c7f3b098299be"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.3.0/opam
+++ b/packages/srt-windows/srt-windows.0.3.0/opam
@@ -23,17 +23,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 patches: [
   "patches/fix-wine-call.patch"
@@ -52,3 +43,4 @@ url {
     "sha512=a79286afeed4f8ef161b9fe1f32e54581ef658f25975727351478b0a1fe16975f5c5b47f247dae4909df73f75ce8022b2201c1272f78528bf11efe8507174820"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.3.2/opam
+++ b/packages/srt-windows/srt-windows.0.3.2/opam
@@ -23,17 +23,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["libsrt"] {os-distribution = "mxe"}
@@ -45,3 +36,4 @@ url {
     "sha512=8051282fbfcf271d388e46dea6d3816ac9928fd456ca1ead50b9248d2c092c54dc2325bb76cb3e47fddfbaab9c5cb396cf55b0423a1fda4bf65ceb8197993030"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.3.3/opam
+++ b/packages/srt-windows/srt-windows.0.3.3/opam
@@ -27,17 +27,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-srt.git"
 conflicts: [ "ocaml-option-bytecode-only" ]
@@ -49,3 +40,4 @@ url {
     "sha512=567aa2dd05ca9d1b20dcf81bc8d38dc21d0e7e9f75b8f54097f98c33656ae237f22d70eac7505f15a14ed4ecf1da38f45176b2a0900b623c770802656005230b"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/srt-windows/srt-windows.0.3.4/opam
+++ b/packages/srt-windows/srt-windows.0.3.4/opam
@@ -27,17 +27,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "srt"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "srt" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-srt.git"
 conflicts: [ "ocaml-option-bytecode-only" ]
@@ -49,3 +40,4 @@ url {
     "sha512=250e385736933ea5b73c86208b7a3a63dfea425f50abeea98d88508a893c040d4f0ce7a3ae8e37dd99ee942911f92df382a45bd088da179c37df2ca1398d314d"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "srt"]

--- a/packages/ssl-windows/ssl-windows.0.5.13/opam
+++ b/packages/ssl-windows/ssl-windows.0.5.13/opam
@@ -7,6 +7,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" "ssl" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.02.0"}
@@ -27,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "d9f9695947498b43afe47d7078b6d53f77104717"
+install: ["dune" "install" "-x" "windows" "-p" "ssl"]

--- a/packages/ssl-windows/ssl-windows.0.5.9/opam
+++ b/packages/ssl-windows/ssl-windows.0.5.9/opam
@@ -5,6 +5,7 @@ dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
 bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 build: [
   ["dune" "build" "-p" "ssl" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 remove: [["ocamlfind" "-toolchain" "windows" "remove" "ssl"]]
 depends: [
@@ -27,3 +28,4 @@ url {
 depexts: [
   ["openssl"] {os-distribution = "mxe"}
 ]
+install: ["dune" "install" "-x" "windows" "-p" "ssl"]

--- a/packages/ssl-windows/ssl-windows.0.7.0/opam
+++ b/packages/ssl-windows/ssl-windows.0.7.0/opam
@@ -16,17 +16,8 @@ build-env: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "ssl"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "ssl" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["openssl"] {os-distribution = "mxe"}
@@ -39,3 +30,4 @@ url {
     "sha512=969c4d64828449a49bdef26ca5f8faa72d2fe2a2304ccbf589a3ff097c2bf8ae9eb83ae1c90216f6b4d6f359e462ea47e0106a7386e26848d14910138fcb07f8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "ssl"]

--- a/packages/stdint-windows/stdint-windows.0.7.2/opam
+++ b/packages/stdint-windows/stdint-windows.0.7.2/opam
@@ -28,17 +28,8 @@ depends: [
 dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "stdint"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "stdint" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -49,3 +40,4 @@ url {
   ]
 }
 x-commit-hash: "11c1e6b4e6ef4142cff0f82b685b317284e354c5"
+install: ["dune" "install" "-x" "windows" "-p" "stdint"]

--- a/packages/stdio-windows/stdio-windows.v0.16.0/opam
+++ b/packages/stdio-windows/stdio-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "stdio" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.14.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/stdio-v0.16.0.tar.gz"
 checksum: "sha256=61f0b75950614ac5378c6ec0d822cce6463402d919d5810b736fc46522b3a73e"
 }
+install: ["dune" "install" "-x" "windows" "-p" "stdio"]

--- a/packages/stdio-windows/stdio-windows.v0.17.0/opam
+++ b/packages/stdio-windows/stdio-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "stdio" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -26,3 +27,4 @@ url {
 src: "https://github.com/janestreet/stdio/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=e7cb473d4bffcf419f307c658cf2599fab03a2b4fe655bfd0be699f8f7af176e"
 }
+install: ["dune" "install" "-x" "windows" "-p" "stdio"]

--- a/packages/stdlib-shims-windows/stdlib-shims-windows.0.1.0/opam
+++ b/packages/stdlib-shims-windows/stdlib-shims-windows.0.1.0/opam
@@ -11,7 +11,17 @@ depends: [
   "dune"
   "ocaml-windows"
 ]
-build: [ "dune" "build" "-x" "windows" "-p" "stdlib-shims" "-j" jobs ]
+build: [
+  ["dune"
+  "build"
+  "-x"
+  "windows"
+  "-p"
+  "stdlib-shims"
+  "-j"
+  jobs]
+  ["rm" "%{name}%.install"]
+]
 synopsis: "Backport some of the new stdlib features to older compiler"
 description: """
 Backport some of the new stdlib features to older compiler,
@@ -25,3 +35,4 @@ url {
     "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
   checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "stdlib-shims"]

--- a/packages/stdlib-shims-windows/stdlib-shims-windows.0.3.0/opam
+++ b/packages/stdlib-shims-windows/stdlib-shims-windows.0.3.0/opam
@@ -11,7 +11,17 @@ depends: [
   "dune"
   "ocaml-windows" {>= "4.02.3"}
 ]
-build: [ "dune" "build" "-p" "stdlib-shims" "-x" "windows" "-j" jobs ]
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "stdlib-shims"
+  "-x"
+  "windows"
+  "-j"
+  jobs]
+  ["rm" "%{name}%.install"]
+]
 synopsis: "Backport some of the new stdlib features to older compiler"
 description: """
 Backport some of the new stdlib features to older compiler,
@@ -29,3 +39,4 @@ url {
     "sha512=1151d7edc8923516e9a36995a3f8938d323aaade759ad349ed15d6d8501db61ffbe63277e97c4d86149cf371306ac23df0f581ec7e02611f58335126e1870980"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "stdlib-shims"]

--- a/packages/stdune-windows/stdune-windows.3.19.1/opam
+++ b/packages/stdune-windows/stdune-windows.3.19.1/opam
@@ -21,17 +21,8 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["rm" "-rf" "vendor/csexp"]
   ["rm" "-rf" "vendor/pp"]
-  [
-    "dune"
-    "build"
-    "-p"
-    "stdune,dyn"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "stdune,dyn" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -42,3 +33,4 @@ url {
   ]
 }
 x-commit-hash: "76c0c3941798f81dcc13a305d7abb120c191f5fa"
+install: ["dune" "install" "-x" "windows" "-p" "stdune"]

--- a/packages/stringext-windows/stringext-windows.1.6.0/opam
+++ b/packages/stringext-windows/stringext-windows.1.6.0/opam
@@ -11,6 +11,7 @@ depends: [
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "stringext" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/rgrinberg/stringext.git"
 synopsis: "Extra string functions for OCaml"
@@ -26,3 +27,4 @@ url {
     "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "stringext"]

--- a/packages/taglib-windows/taglib-windows.0.3.10/opam
+++ b/packages/taglib-windows/taglib-windows.0.3.10/opam
@@ -14,17 +14,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "taglib"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "taglib" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
  ["taglib"] {os-distribution = "mxe"}
@@ -37,3 +28,4 @@ url {
     "sha512=70193babf3ddca744de00ad43de12d71bdfbdd2d2081435a546ecccd1ead15c20b2ea91e226a98638935c20d6cd546e4b20111164a28255867192acec1a78ef2"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "taglib"]

--- a/packages/taglib-windows/taglib-windows.0.3.7/opam
+++ b/packages/taglib-windows/taglib-windows.0.3.7/opam
@@ -32,6 +32,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
  ["taglib"] {os-distribution = "mxe"}
@@ -44,3 +45,4 @@ url {
     "sha512=04e498d1fc2e3937bc25583175436d1cee8a25aabfdf43df4f30d1878aac97fde1d25be8dca44273fb2223785c3872088d667d6ba3e6cc644730b2f9b4d0491f"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "taglib"]

--- a/packages/taglib-windows/taglib-windows.0.3.9/opam
+++ b/packages/taglib-windows/taglib-windows.0.3.9/opam
@@ -20,17 +20,8 @@ depends: [
   "dune-configurator"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "taglib"
-    "-x"
-    "windows"
-    "-j"
-    jobs
-    "@install"
-  ]
+  ["dune" "build" "-p" "taglib" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
  ["taglib"] {os-distribution = "mxe"}
@@ -43,3 +34,4 @@ url {
     "sha512=7ec9cd2439c10079be0ab96a759557ef7254bd5dbb49fb82f8d628b880a70b0f768c22fd6b69100567eda67290b2c3c9272addb2ae3578e050a6a891688e2427"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "taglib"]

--- a/packages/theora-windows/theora-windows.0.4.0/opam
+++ b/packages/theora-windows/theora-windows.0.4.0/opam
@@ -13,17 +13,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "theora"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "theora" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["theora"] {os-distribution = "mxe"}
@@ -36,3 +27,4 @@ url {
     "sha512=513765188edc36219df0fb4d9801d2483e53a545c5491a22eaf4274b4b9c8a950d1d58063ffa0ac02639af1362c4fd0ce56ea3d3dccfd6e330929de15b30ce0e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "theora"]

--- a/packages/time_now-windows/time_now-windows.v0.14.0/opam
+++ b/packages/time_now-windows/time_now-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/time_now/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "time_now" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"               {>= "4.04.2"}
@@ -29,3 +30,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/time_now-v0.14.0.tar.gz"
   checksum: "md5=a93116938783587f8b9f5152dd543037"
 }
+install: ["dune" "install" "-x" "windows" "-p" "time_now"]

--- a/packages/time_now-windows/time_now-windows.v0.16.0/opam
+++ b/packages/time_now-windows/time_now-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/time_now/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "time_now" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"               {>= "4.14.0"}
@@ -29,3 +30,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/time_now-v0.16.0.tar.gz"
 checksum: "sha256=5fa084aadee6aaedbb8976e4a2bc0c1dfe69eecdd0576ff901f21eedd46dc3a1"
 }
+install: ["dune" "install" "-x" "windows" "-p" "time_now"]

--- a/packages/time_now-windows/time_now-windows.v0.17.0/opam
+++ b/packages/time_now-windows/time_now-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/time_now/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "time_now" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows"               {>= "5.1.0"}
@@ -30,3 +31,4 @@ url {
 src: "https://github.com/janestreet/time_now/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=fc85d6e46c4eb9370de9385f7bbfa6d57b4e48a9e96b20009007226b73f9530c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "time_now"]

--- a/packages/tls-lwt-windows/tls-lwt-windows.2.0.0/opam
+++ b/packages/tls-lwt-windows/tls-lwt-windows.2.0.0/opam
@@ -8,8 +8,8 @@ license:      "BSD-2-Clause"
 
 build: [
   ["dune" "build" "-p" "tls-lwt" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.13.0"}
   "dune" {>= "3.0"}
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "a1ba8944ded768ca439a4ded809a819042ffcb1e"
+install: ["dune" "install" "-x" "windows" "-p" "tls-lwt"]

--- a/packages/tls-windows/tls-windows.2.0.0/opam
+++ b/packages/tls-windows/tls-windows.2.0.0/opam
@@ -8,8 +8,8 @@ license:      "BSD-2-Clause"
 
 build: [
   ["dune" "build" "-p" "tls" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml-windows" {>= "4.13.0"}
   "dune" {>= "3.0"}
@@ -57,3 +57,4 @@ url {
   ]
 }
 x-commit-hash: "a1ba8944ded768ca439a4ded809a819042ffcb1e"
+install: ["dune" "install" "-x" "windows" "-p" "tls"]

--- a/packages/toml-windows/toml-windows.5.0.0/opam
+++ b/packages/toml-windows/toml-windows.5.0.0/opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/mackwic/To.ml/issues"
 dev-repo: "git+https://github.com/mackwic/To.ml.git"
 build: [
   ["dune" "build" "-p" "toml" "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 license: "LGPL-3.0-only"
 depends: [
@@ -33,3 +34,4 @@ url {
   src: "https://github.com/ocaml-toml/to.ml/archive/v5.0.0.tar.gz"
   checksum: "md5=e68d21fdbb6b255909305f8707a54951"
 }
+install: ["dune" "install" "-x" "windows" "-p" "toml"]

--- a/packages/tsort-windows/tsort-windows.1.0.0/opam
+++ b/packages/tsort-windows/tsort-windows.1.0.0/opam
@@ -16,6 +16,7 @@ dev-repo: "git+https://github.com/dmbaturin/ocaml-tsort.git"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "tsort" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.03.0"}
@@ -30,3 +31,4 @@ url {
     "sha512=b4153c9f266b2b8f468e04e9c3823a9c2a14a92d463825a0b8f1d5777091c425b9327d4f5518fb72ba0b04fc9b54b03fc3a49eeb85e252e9c0cddb06adb7ffb6"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "tsort"]

--- a/packages/tsort-windows/tsort-windows.2.0.0/opam
+++ b/packages/tsort-windows/tsort-windows.2.0.0/opam
@@ -18,7 +18,17 @@ depends: [
   "containers-windows" {>= "2.7"}
   "dune" {>= "1.9"}
 ]
-build: ["dune" "build" "-p" "tsort" "-x" "windows" "-j" jobs]
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "tsort"
+  "-x"
+  "windows"
+  "-j"
+  jobs]
+  ["rm" "%{name}%.install"]
+]
 dev-repo: "git+https://github.com/dmbaturin/ocaml-tsort.git"
 url {
   src: "https://github.com/dmbaturin/ocaml-tsort/archive/2.0.0.zip"
@@ -28,3 +38,4 @@ url {
   ]
 }
 
+install: ["dune" "install" "-x" "windows" "-p" "tsort"]

--- a/packages/typerep-windows/typerep-windows.v0.14.0/opam
+++ b/packages/typerep-windows/typerep-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "typerep" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2"}
@@ -21,3 +22,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/typerep-v0.14.0.tar.gz"
   checksum: "md5=a1d10bec724e500fd2f6b7798fc0409c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "typerep"]

--- a/packages/typerep-windows/typerep-windows.v0.16.0/opam
+++ b/packages/typerep-windows/typerep-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "typerep" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.14.0" & < "5.3"}
@@ -21,3 +22,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/typerep-v0.16.0.tar.gz"
 checksum: "sha256=e5157fef61e0229dacf01a5677bb93416ab59ee86046904c3d691e872ed4f72c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "typerep"]

--- a/packages/typerep-windows/typerep-windows.v0.17.1/opam
+++ b/packages/typerep-windows/typerep-windows.v0.17.1/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "typerep" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -24,3 +25,4 @@ url {
     "sha512=e81434ced58ab1cf3cb61d0e2c2106d81c81fe040130cfe07bb79dc3dcc834b1f51dec0faf50e06ccf8cac831e39f31a2ff4ca3dabef7bbaa61f85f13d7f44f5"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "typerep"]

--- a/packages/uri-sexp-windows/uri-sexp-windows.4.4.0/opam
+++ b/packages/uri-sexp-windows/uri-sexp-windows.4.4.0/opam
@@ -21,6 +21,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "uri-sexp" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -31,3 +32,4 @@ url {
   ]
 }
 x-commit-hash: "c336c796f4deb8979a4c7ceea3bef34b46240623"
+install: ["dune" "install" "-x" "windows" "-p" "uri-sexp"]

--- a/packages/uri-windows/uri-windows.4.4.0/opam
+++ b/packages/uri-windows/uri-windows.4.4.0/opam
@@ -22,6 +22,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" "uri" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -32,3 +33,4 @@ url {
   ]
 }
 x-commit-hash: "c336c796f4deb8979a4c7ceea3bef34b46240623"
+install: ["dune" "install" "-x" "windows" "-p" "uri"]

--- a/packages/variantslib-windows/variantslib-windows.v0.12.0/opam
+++ b/packages/variantslib-windows/variantslib-windows.v0.12.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "variantslib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/variantslib-v0.12.0.tar.gz"
   checksum: "md5=77f75c873ccc397c8c7776ebf7a3f88c"
 }
+install: ["dune" "install" "-x" "windows" "-p" "variantslib"]

--- a/packages/variantslib-windows/variantslib-windows.v0.14.0/opam
+++ b/packages/variantslib-windows/variantslib-windows.v0.14.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "variantslib" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.04.2"}
@@ -25,3 +26,4 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/variantslib-v0.14.0.tar.gz"
   checksum: "md5=c0a0481de7df3df028bdec76d9993892"
 }
+install: ["dune" "install" "-x" "windows" "-p" "variantslib"]

--- a/packages/variantslib-windows/variantslib-windows.v0.16.0/opam
+++ b/packages/variantslib-windows/variantslib-windows.v0.16.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "variantslib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "4.14.0"}
@@ -24,3 +25,4 @@ url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/variantslib-v0.16.0.tar.gz"
 checksum: "sha256=27ae7ad0bc123861c49c3cc0a74f01e68f91d3fb6c52c84505764e96a89d372f"
 }
+install: ["dune" "install" "-x" "windows" "-p" "variantslib"]

--- a/packages/variantslib-windows/variantslib-windows.v0.17.0/opam
+++ b/packages/variantslib-windows/variantslib-windows.v0.17.0/opam
@@ -8,6 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
 license: "MIT"
 build: [
   ["dune" "build" "-p" "variantslib" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "ocaml-windows" {>= "5.1.0"}
@@ -25,3 +26,4 @@ url {
 src: "https://github.com/janestreet/variantslib/archive/refs/tags/v0.17.0.tar.gz"
 checksum: "sha256=9874b69aec9cfe6331970eb2271f7c24e5433ba696c1a9ea5a429862b62338ab"
 }
+install: ["dune" "install" "-x" "windows" "-p" "variantslib"]

--- a/packages/vorbis-windows/vorbis-windows.0.8.0/opam
+++ b/packages/vorbis-windows/vorbis-windows.0.8.0/opam
@@ -14,17 +14,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  [
-    "dune"
-    "build"
-    "-p"
-    "vorbis"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "vorbis" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 depexts: [
   ["vorbis"] {os-distribution = "mxe"}
@@ -37,3 +28,4 @@ url {
     "sha512=b2d3940492552fdda27785623cc563758aca061fedfdf577ab1ef22fb1958c27af9fe68c1ed7bd5cf323e1a1b7b42cc53ae6d2c09dc6cae7ead37f740d106ba8"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "vorbis"]

--- a/packages/winsvc-windows/winsvc-windows.1.0.0/opam
+++ b/packages/winsvc-windows/winsvc-windows.1.0.0/opam
@@ -11,17 +11,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {pinned}
-  [
-    "dune"
-    "build"
-    "-p"
-    "winsvc"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "winsvc" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-winsvc.git"
 url {
@@ -31,3 +22,4 @@ url {
     "sha512=30e208d35ed7eb30e90d5fd4f0dde3ff4f527155df90e2d9cffadec15513b65b72503fc223bd784203f2b9081f68bedd5a2b157ffb0b2d9b765546dac1094875"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "winsvc"]

--- a/packages/winsvc-windows/winsvc-windows.1.0.1/opam
+++ b/packages/winsvc-windows/winsvc-windows.1.0.1/opam
@@ -24,6 +24,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-winsvc.git"
 url {
@@ -33,3 +34,4 @@ url {
     "sha512=d63a033d590d910239a377ef128847328b377ff2974e5e20e0daa5460d9fa6d3102c3205159b9c5ddce049bd43e96adb7ce4fdab24141832119196f006f68fb3"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "winsvc"]

--- a/packages/x509-windows/x509-windows.1.0.5/opam
+++ b/packages/x509-windows/x509-windows.1.0.5/opam
@@ -32,6 +32,7 @@ depends: [
 conflicts: [ "result-windows" {< "1.5"} ]
 build: [
   ["dune" "build" "-p" "x509" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
 synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
@@ -54,3 +55,4 @@ url {
 }
 x-commit-hash: "297df4ce6002deae0c34409cf505a09905699427"
 x-maintenance-intent: [ "(latest)" ]
+install: ["dune" "install" "-x" "windows" "-p" "x509"]

--- a/packages/xdg-windows/xdg-windows.3.2.0/opam
+++ b/packages/xdg-windows/xdg-windows.3.2.0/opam
@@ -16,17 +16,8 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
   ["rm" "-rf" "vendor/csexp"]
   ["rm" "-rf" "vendor/pp"]
-  [
-    "dune"
-    "build"
-    "-p"
-    "xdg"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "xdg" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 url {
   src:
@@ -37,3 +28,4 @@ url {
   ]
 }
 x-commit-hash: "43af00f79e41ce9101d42b36dab13e1f68d49a7a"
+install: ["dune" "install" "-x" "windows" "-p" "xdg"]

--- a/packages/xml-light-windows/xml-light-windows.2.5/opam
+++ b/packages/xml-light-windows/xml-light-windows.2.5/opam
@@ -15,7 +15,17 @@ depends: [
   "ocaml-windows" {>= "4.03"}
   "dune" {>= "2.7"}
 ]
-build: ["dune" "build" "-p" "xml-light" "-j" jobs "-x" "windows"]
+build: [
+  ["dune"
+  "build"
+  "-p"
+  "xml-light"
+  "-j"
+  jobs
+  "-x"
+  "windows"]
+  ["rm" "%{name}%.install"]
+]
 dev-repo: "git+https://github.com/ncannasse/xml-light"
 url {
   src:
@@ -26,3 +36,4 @@ url {
   ]
 }
 x-commit-hash: "fd62588fb7515e61d43771d885f585d3cd3fb9ca"
+install: ["dune" "install" "-x" "windows" "-p" "xml-light"]

--- a/packages/xmlplaylist-windows/xmlplaylist-windows.0.1.5/opam
+++ b/packages/xmlplaylist-windows/xmlplaylist-windows.0.1.5/opam
@@ -12,17 +12,8 @@ depends: [
   "xmlm-windows"
 ]
 build: [
-  [
-    "dune"
-    "build"
-    "-p"
-    "xmlplaylist"
-    "-j"
-    jobs
-    "-x"
-    "windows"
-    "@install"
-  ]
+  ["dune" "build" "-p" "xmlplaylist" "-j" jobs "-x" "windows" "@install"]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-xmlplaylist.git"
 url {
@@ -32,3 +23,4 @@ url {
     "sha512=e49f0025405c6a1b8b70c3e387e03c246650ffd1a47d984a2f84c9e2d5a69eb6a146cc351140cff367a8e8ca758b22298e08c9b5dcf04ecfef04831dcc73a13e"
   ]
 }
+install: ["dune" "install" "-x" "windows" "-p" "xmlplaylist"]

--- a/packages/yojson-five-windows/yojson-five-windows.2.2.2/opam
+++ b/packages/yojson-five-windows/yojson-five-windows.2.2.2/opam
@@ -37,6 +37,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 url {
@@ -48,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "3f82b79d1865eec82c6f498ee1835a90c74c31b4"
+install: ["dune" "install" "-x" "windows" "-p" "yojson-five"]

--- a/packages/yojson-windows/yojson-windows.1.5.0/opam
+++ b/packages/yojson-windows/yojson-windows.1.5.0/opam
@@ -6,7 +6,8 @@ bug-reports: "https://github.com/ocaml-community/yojson/issues"
 dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 doc: "https://ocaml-community.github.io/yojson/"
 build: [
-  ["dune" "build"  "-p" "yojson" "-j" jobs "-x" "windows"]
+  ["dune" "build" "-p" "yojson" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
 depends: [
   "dune" {build}
@@ -32,3 +33,4 @@ url {
     "https://github.com/ocaml-community/yojson/releases/download/1.5.0/yojson-1.5.0.tbz"
   checksum: "md5=d80de1bacdde292af42f7c78b323da7b"
 }
+install: ["dune" "install" "-x" "windows" "-p" "yojson"]

--- a/packages/yojson-windows/yojson-windows.1.7.0/opam
+++ b/packages/yojson-windows/yojson-windows.1.7.0/opam
@@ -8,8 +8,8 @@ doc: "https://ocaml-community.github.io/yojson/"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" "yojson" "-j" jobs "-x" "windows"]
+  ["rm" "%{name}%.install"]
 ]
-
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune"
@@ -35,3 +35,4 @@ url {
     "https://github.com/ocaml-community/yojson/releases/download/1.7.0/yojson-1.7.0.tbz"
   checksum: "md5=b89d39ca3f8c532abe5f547ad3b8f84d"
 }
+install: ["dune" "install" "-x" "windows" "-p" "yojson"]

--- a/packages/yojson-windows/yojson-windows.2.1.0/opam
+++ b/packages/yojson-windows/yojson-windows.2.1.0/opam
@@ -38,6 +38,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 url {
@@ -49,3 +50,4 @@ url {
   ]
 }
 x-commit-hash: "42fa0887cb870bdbd1751d98cd23f99d6b29751d"
+install: ["dune" "install" "-x" "windows" "-p" "yojson"]

--- a/packages/yojson-windows/yojson-windows.2.2.2/opam
+++ b/packages/yojson-windows/yojson-windows.2.2.2/opam
@@ -37,6 +37,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["rm" "%{name}%.install"]
 ]
 dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 url {
@@ -48,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "3f82b79d1865eec82c6f498ee1835a90c74c31b4"
+install: ["dune" "install" "-x" "windows" "-p" "yojson"]


### PR DESCRIPTION
Potential workaround for #398 suggested by @kit-ty-kate [#opam > Cross compilation with opam 2.5.1 @ 💬](https://ocaml.zulipchat.com/#narrow/channel/527832-opam/topic/Cross.20compilation.20with.20opam.202.2E5.2E1/near/592352231)


Basic tests locally suggest this works, and I'm currently trying it in my CI over at https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FStanc3/detail/PR-1618/2/pipeline.

This was done via opam-ed with a few manual patches for files that no longer passed `opam lint` after.

file patch.sh:
```bash
#!/bin/bash

if opam-ed -f "$1" 'get build' | grep dune -q; then
    echo "Patching $1"
    name=$(echo "$1" | cut -d/ -f3 | sed 's/-windows//')
    opam-ed -i -f "$1" \
            'append build ["rm" "%{name}%.install"]' \
            "add-replace install [\"dune\" \"install\" \"-x\" \"windows\" \"-p\" \"$name\"]"
    #opam lint "$1"
    exit 0
fi

echo "Skipping $1"
```

```bash
find -iname opam -type f | xargs -n1 ./patch.sh 
```