### PR TITLE
posix-base-windows, posix-socket-windows: add 4.0.2

### DIFF
--- a/packages/ctypes-foreign-windows/ctypes-foreign-windows.0.24.0/files/patches/fix-config.patch
+++ b/packages/ctypes-foreign-windows/ctypes-foreign-windows.0.24.0/files/patches/fix-config.patch
@@ -1,0 +1,16 @@
+diff --git a/src/ctypes-foreign/config/discover.ml b/src/ctypes-foreign/config/discover.ml
+index 7be7ae3..85de869 100644
+--- a/src/ctypes-foreign/config/discover.ml
++++ b/src/ctypes-foreign/config/discover.ml
+@@ -14,10 +14,7 @@ let () =
+            | None -> default
+            | Some v -> v)
+       in
+-      let backend =
+-        match Sys.os_type with
+-        | "Win32" | "Cygwin" -> "win"
+-        | _ -> "unix" in
++      let backend = "win" in
+
+       let f = "as_needed_test" in
+       let ml = f ^ ".ml" in

--- a/packages/ctypes-foreign-windows/ctypes-foreign-windows.0.24.0/opam
+++ b/packages/ctypes-foreign-windows/ctypes-foreign-windows.0.24.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Dynamic access to foreign C libraries using Ctypes"
+description: """
+
+This installs the `ctypes-foreign` interface which
+uses `libffi` to provide dynamic access to foreign libraries."""
+maintainer: ["Jeremy Yallop <yallop@gmail.com>"]
+authors: ["Jeremy Yallop"]
+license: "MIT"
+tags: ["org:mirage"]
+homepage: "https://github.com/yallop/ocaml-ctypes"
+doc: "https://yallop.github.io/ocaml-ctypes/"
+bug-reports: "https://github.com/yallop/ocaml-ctypes/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml-windows" {>= "4.07.0"}
+  "ctypes-windows" {= version}
+  "dune-configurator"
+]
+build-env: [
+  [PKG_CONFIG = "%{conf-gcc-windows64:prefix}%pkg-config"]
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" "ctypes-foreign" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
+]
+extra-files: [
+  ["patches/fix-config.patch" "md5=aabfea16327b5549e9a559f3ae99ba21"]
+]
+patches: [
+  "patches/fix-config.patch"
+]
+depexts: [
+  ["libffi"] {os-distribution = "mxe"}
+]
+dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
+url {
+  src:
+    "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.24.0.tar.gz"
+  checksum: [
+    "sha256=249c5604c8554659761a7282db4ad200aa8c0fdc408cdb53102bd70feeb51955"
+    "md5=064316aaf508a9db203f114bb8401dee"
+  ]
+}
+install: ["dune" "install" "-x" "windows" "-p" "ctypes-foreign"]

--- a/packages/ctypes-windows/ctypes-windows.0.24.0/opam
+++ b/packages/ctypes-windows/ctypes-windows.0.24.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Combinators for binding to C libraries without writing any C"
+description: """
+
+ctypes is a library for binding to C libraries using pure OCaml. The primary
+aim is to make writing C extensions as straightforward as possible.
+The core of ctypes is a set of combinators for describing the structure of C
+types -- numeric types, arrays, pointers, structs, unions and functions. You
+can use these combinators to describe the types of the functions that you want
+to call, then bind directly to those functions -- all without writing or
+generating any C!
+
+To install the optional `ctypes-foreign` interface (which uses `libffi` to
+provide dynamic access to foreign libraries), you will need to also install
+the `ctypes-foreign` package.
+
+    opam install ctypes-foreign
+
+This will make the `ctypes-foreign` ocamlfind subpackage available."""
+maintainer: ["Jeremy Yallop <yallop@gmail.com>"]
+authors: ["Jeremy Yallop"]
+license: "MIT"
+tags: ["org:mirage"]
+homepage: "https://github.com/yallop/ocaml-ctypes"
+doc: "https://yallop.github.io/ocaml-ctypes/"
+bug-reports: "https://github.com/yallop/ocaml-ctypes/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml-windows" {>= "4.07.0"}
+  "integers"
+  "integers-windows"
+  "dune-configurator"
+  "dune-configurator-windows"
+]
+build: [
+  ["dune" "build" "-p" "ctypes" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
+url {
+  src:
+    "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.24.0.tar.gz"
+  checksum: [
+    "sha256=249c5604c8554659761a7282db4ad200aa8c0fdc408cdb53102bd70feeb51955"
+    "md5=064316aaf508a9db203f114bb8401dee"
+  ]
+}
+install: ["dune" "install" "-x" "windows" "-p" "ctypes"]

--- a/packages/posix-base-windows/posix-base-windows.4.0.2/opam
+++ b/packages/posix-base-windows/posix-base-windows.4.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Base module for the posix bindings"
+description: "posix-base provides base tools for the posix binding modules."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml-windows" {>= "4.08"}
+  "integers" {>= "0.3.0"}
+  "integers-windows" {>= "0.3.0"}
+  "ctypes" {>= "0.24.0"}
+  "ctypes-windows" {>= "0.24.0"}
+]
+build: [
+  ["dune" "build" "-p" "posix-base" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+url {
+  src:
+    "https://github.com/savonet/ocaml-posix/archive/refs/tags/v4.0.2.tar.gz"
+  checksum: [
+    "md5=2e05f3e890206138c4ebd09878359a2f"
+    "sha512=79a786c299b5d9f7f5ff0c3cf289539e8ea257b2068f75cd9faca9450679e5cd7de6b0fc5b77c9ddbbb5857d4f64119837a61a22d277e6e2a8ab4b3c4d5911c0"
+  ]
+}
+install: ["dune" "install" "-x" "windows" "-p" "posix-base"]

--- a/packages/posix-socket-windows/posix-socket-windows.4.0.2/opam
+++ b/packages/posix-socket-windows/posix-socket-windows.4.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Bindings for posix sockets"
+description:
+  "posix-socket provides the types and bindings of posix sockets APIs available on both unix and windows."
+maintainer: ["romain.beauxis@gmail.com"]
+authors: ["Romain Beauxis"]
+license: "MIT"
+homepage: "https://github.com/savonet/ocaml-posix"
+bug-reports: "https://github.com/savonet/ocaml-posix/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml-windows" {>= "4.12"}
+  "dune-configurator"
+  "posix-base" {= version}
+  "posix-base-windows" {= version}
+  "ctypes"
+  "ctypes-windows"
+]
+build: [
+  ["dune" "build" "-p" "posix-socket" "-x" "windows" "-j" jobs "@install"]
+  ["rm" "%{name}%.install"]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-posix.git"
+url {
+  src:
+    "https://github.com/savonet/ocaml-posix/archive/refs/tags/v4.0.2.tar.gz"
+  checksum: [
+    "md5=2e05f3e890206138c4ebd09878359a2f"
+    "sha512=79a786c299b5d9f7f5ff0c3cf289539e8ea257b2068f75cd9faca9450679e5cd7de6b0fc5b77c9ddbbb5857d4f64119837a61a22d277e6e2a8ab4b3c4d5911c0"
+  ]
+}
+install: ["dune" "install" "-x" "windows" "-p" "posix-socket"]


### PR DESCRIPTION
Adds cross-compilation opam packages for the 4.0.2 release of `posix-base` and `posix-socket` from the [ocaml-posix](https://github.com/savonet/ocaml-posix) monorepo.

Both `posix-base-windows` and `posix-socket-windows` are updated together since the native `posix-socket` now depends on `posix-base {= version}`, requiring both to be available at the same version.

Notable changes from 3.0.0:
- `dune >= "3.20"` (was `2.9`)
- New native `dune-configurator` dependency in posix-socket (used for C probing at build time)
- `posix-base {= version}` / `posix-base-windows {= version}` strict version pinning (was `>= "2.2"`)
- `ctypes >= "0.24.0"` for posix-base (was unversioned)
- Source tarball URL format changed to `refs/tags/v4.0.2.tar.gz`
