### PR TITLE
+digestif-windows.1.3.0

### DIFF
--- a/packages/digestif-windows/digestif-windows.1.3.0/opam
+++ b/packages/digestif-windows/digestif-windows.1.3.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  ["dune" "build" "-p" "digestif" "-x" "windows" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
+install: ["dune" "install" "-x" "windows" "-p" "digestif"]
+
+depends: [
+  "ocaml-windows"  {>= "4.08.0"}
+  "dune"           {>= "2.6.0"}
+  "eqaf-windows"
+]
+
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v1.3.0/digestif-1.3.0.tbz"
+  checksum: [
+    "sha256=9a6cdcb332539c87f4723fc3bd73626b2675a7b1161fdf0fed309186ce18f427"
+    "sha512=986d98eeb79f75ff69842a7ed4b93b4ff3795df7c09d455ca0c41408d67415a6743253a96c7e0de653dc62db95cb1fd29b1c654472fa11259cddde65dd5dd352"
+  ]
+}
+x-commit-hash: "0763eb3b34ac8881925c4f50055f4bff3808aed4"


### PR DESCRIPTION
Adds `digestif-windows.1.3.0`, a cross-compilation package for [digestif](https://github.com/mirage/digestif) targeting Windows.

The only non-test runtime dependency is `eqaf`, which already has `eqaf-windows.0.10` in this repo.